### PR TITLE
Audit: Address #20

### DIFF
--- a/contracts/EricOrb.sol
+++ b/contracts/EricOrb.sol
@@ -832,12 +832,12 @@ contract EricOrb is ERC721, Ownable {
 
     /// @notice  Triggers the orb (otherwise known as Orb Invocation). Allows the holder to submit cleartext.
     /// @param  cleartext  Required cleartext.
-    function trigger(string memory cleartext) external {
+    function triggerText(string memory cleartext) external {
         uint256 length = bytes(cleartext).length;
         if (length > MAX_CLEARTEXT_LENGTH) {
             revert CleartextTooLong(length, MAX_CLEARTEXT_LENGTH);
         }
-        trigger(keccak256(abi.encodePacked(cleartext)));
+        triggerHash(keccak256(abi.encodePacked(cleartext)));
     }
 
   /**
@@ -851,7 +851,7 @@ contract EricOrb is ERC721, Ownable {
    *          Emits Triggered().
    * @param   contentHash  Required keccak256 hash of the cleartext.
    */
-  function trigger(bytes32 contentHash) public onlyHolder onlyHolderHeld onlyHolderSolvent {
+  function triggerHash(bytes32 contentHash) public onlyHolder onlyHolderHeld onlyHolderSolvent {
     if (block.timestamp < lastTriggerTime + COOLDOWN) {
       revert CooldownIncomplete(lastTriggerTime + COOLDOWN - block.timestamp);
     }


### PR DESCRIPTION
@lekevicius It broke hardhat tests and I can't seem to be able to fix it (not important due to the test migration to foundry). 

The issue is that it doesn't generate `trigger` bindings when we overload the function.

Fixes #20

