### PR TITLE
Merge fixes

### DIFF
--- a/contracts/EricOrb.sol
+++ b/contracts/EricOrb.sol
@@ -834,10 +834,12 @@ contract EricOrb is ERC721, Ownable {
    * @param   triggerId  Triggred id, matching the one that was emitted when calling {trigger()}.
    * @param   cleartext  Cleartext, limited to tweet length. Must match the content hash.
    */
-  function recordTriggerCleartext(
-    uint256 triggerId,
-    string memory cleartext
-  ) external view onlyHolder onlyHolderHeld onlyHolderSolvent {
+    function recordTriggerCleartext(uint256 triggerId, string memory cleartext)
+        external
+        view
+        onlyHolder
+        onlyHolderSolvent
+    {
     uint256 cleartextLength = bytes(cleartext).length;
 
     if (cleartextLength > MAX_CLEARTEXT_LENGTH) {


### PR DESCRIPTION
This PR fixes a couple of small issues introduced when merging, or missed during audit.

- onlyHolder documentation update
- added missing NatSpec for _transferOrb
- effectiveFundsOf bug fix when owner() is holder
- allowing the new price to be 0 when purchasing (this got overriden by another commit)
- updated NatSpec for purchase to reflect this.
- matched funds checking logic in purchase and bid
- renamed triggerText to triggerWithCleartext, to match naming of recordTriggerCleartext
- brought back triggerId in triggerWithHash, to not do any state modifications in emits
- removed onlyHolderHeld for recordTriggerCleartext — this matches removal conditions but got left unchanged