### PR TITLE
fix: timestamp edge case

### DIFF
--- a/contracts/EricOrb.sol
+++ b/contracts/EricOrb.sol
@@ -896,7 +896,7 @@ contract EricOrb is ERC721, Ownable {
         if (block.timestamp - responseTime > RESPONSE_FLAGGING_PERIOD) {
             revert FlaggingPeriodExpired(triggerId, block.timestamp - responseTime, RESPONSE_FLAGGING_PERIOD);
         }
-        if (holderReceiveTime > responseTime) {
+        if (holderReceiveTime >= responseTime) {
             revert FlaggingPeriodExpired(triggerId, holderReceiveTime, responseTime);
         }
         if (responseFlagged[triggerId]) {


### PR DESCRIPTION
If the owner responds at timestamp A, a new user can buy the orb and flag that response (to the question of the previous user) as long as they do it in the same block as when the respond is issued.

The change adds a small limitation, which is that a user can't flag a response in the same block that it's issued, but it's ok.