### PR TITLE
Emit CleartextRecorded

### DIFF
--- a/src/EricOrb.sol
+++ b/src/EricOrb.sol
@@ -806,8 +806,8 @@ contract EricOrb is ERC721, Ownable {
         if (length > MAX_CLEARTEXT_LENGTH) {
             revert CleartextTooLong(length, MAX_CLEARTEXT_LENGTH);
         }
+        emit CleartextRecorded(triggersCount, cleartext);
         triggerWithHash(keccak256(abi.encodePacked(cleartext)));
-        emit CleartextRecorded(triggersCount - 1, cleartext);
     }
 
     /**

--- a/test/EricOrb.t.sol
+++ b/test/EricOrb.t.sol
@@ -1040,10 +1040,10 @@ contract TriggerWithCleartextTest is EricOrbTestBase {
     function test_callsTriggerHashCorrectly() public {
         string memory text = "fjasdklfjasdklfjasdasdffakfjsad;lfs;lf;flksajf;lk";
         makeHolderAndWarp(user, 1 ether);
-        vm.expectEmit(true, true, false, true);
-        emit Triggered(user, 0, keccak256(abi.encodePacked(text)), block.timestamp);
         vm.expectEmit(true, false, false, true);
         emit CleartextRecorded(0, text);
+        vm.expectEmit(true, true, false, true);
+        emit Triggered(user, 0, keccak256(abi.encodePacked(text)), block.timestamp);
         vm.prank(user);
         orb.triggerWithCleartext(text);
     }


### PR DESCRIPTION
Emitting a new event whenever cleartext is revealed, makes catching recordTriggerCleartext() calls much easier.