### PR TITLE
Bid with price, no deposit minimum

### DIFF
--- a/test/harness/EricOrbHarness.sol
+++ b/test/harness/EricOrbHarness.sol
@@ -13,10 +13,6 @@ contract EricOrbHarness is
         address(0xC0FFEE) // beneficiary
     )
 {
-    function fundsRequiredToBidOneYear(uint256 amount) public pure returns (uint256) {
-        return amount + (amount * HOLDER_TAX_NUMERATOR) / FEE_DENOMINATOR;
-    }
-
     function workaround_orbId() public pure returns (uint256) {
         return ERIC_ORB_ID;
     }


### PR DESCRIPTION
Implements a different approach to having a larger price than just the winning bid, different from "finalize at 2x" as implemented in #71.

- Each bid() call provides a price to use in case of winning the auction
- finalizeAuction() does nothing to the price if auction is won; it just becomes active.

Also, removes the deposit requirement by adjusting fundsRequiredToBid() function to just return the amount itself. Most tests now use the old function as fundsRequiredToBidOneYear(), reflecting the value that will be provided by the frontend.