### PR TITLE
Recall() feature — transferring Orb back to contract after Oath expires

### DIFF
--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -260,9 +260,9 @@ contract Orb is IERC721MetadataUpgradeable, ERC165Upgradeable, OwnableUpgradeabl
     /// Auction minimum duration: the auction will run for at least this long. Initial value is 1 day, and this value
     /// cannot be set to zero, as it would prevent any bids from being made.
     uint256 public auctionMinimumDuration;
-    /// Keeper's Auction minimum duration: auction started by the keeper via `relinquishWithAuction()` will run for at
-    /// least this long. Initial value is 1 day, and this value cannot be set to zero, as it would prevent any bids
-    /// from being made.
+    /// Keeper's Auction minimum duration: auction started by the keeper via `relinquish(true)` will run for at least
+    /// this long. Initial value is 1 day, and this value cannot be set to zero, as it would prevent any bids from being
+    /// made.
     uint256 public auctionKeeperMinimumDuration;
     /// Auction bid extension: if auction remaining time is less than this after a bid is made, auction will continue
     /// for at least this long. Can be set to zero, in which case the auction will always be `auctionMinimumDuration`
@@ -552,8 +552,7 @@ contract Orb is IERC721MetadataUpgradeable, ERC165Upgradeable, OwnableUpgradeabl
     /// @param   newMinimumBidStep         New minimum bid step for the auction. Will always be set to at least 1.
     /// @param   newMinimumDuration        New minimum duration for the auction. Must be > 0.
     /// @param   newKeeperMinimumDuration  New minimum duration for the auction is started by the keeper via
-    ///                                    `relinquishWithAuction()`. Setting to 0 effectively disables keeper
-    ///                                    auctions.
+    ///                                    `relinquish(true)`. Setting to 0 effectively disables keeper auctions.
     /// @param   newBidExtension           New bid extension for the auction. Can be 0.
     function setAuctionParameters(
         uint256 newStartingPrice,
@@ -748,7 +747,7 @@ contract Orb is IERC721MetadataUpgradeable, ERC165Upgradeable, OwnableUpgradeabl
     }
 
     /// @notice  Finalizes the auction, transferring the winning bid to the beneficiary, and the Orb to the winner.
-    ///          If the auction was started by previous Keeper with `relinquishWithAuction()`, then most of the auction
+    ///          If the auction was started by previous Keeper with `relinquish(true)`, then most of the auction
     ///          proceeds (minus the royalty) will be sent to the previous Keeper. Sets `lastInvocationTime` so that
     ///          the Orb could be invoked immediately. The price has been set when bidding, now becomes relevant. If no
     ///          bids were made, resets the state to allow the auction to be started again later.

--- a/src/Orb.sol
+++ b/src/Orb.sol
@@ -398,6 +398,12 @@ contract Orb is IERC721MetadataUpgradeable, ERC165Upgradeable, OwnableUpgradeabl
     ///       modified while it is held by the keeper or users can bid on the Orb.
     modifier onlyCreatorControlled() virtual {
         if (address(this) != keeper && owner() != keeper) {
+            // Creator CAN control (does not revert) if any of these are false:
+            // - Orb is not held by the contract itself
+            // - Orb is not held by the creator
+            // Inverted, this means that the creator CAN control if any of these are true:
+            // - Orb is held by the contract itself OR
+            // - Orb is held by the creator
             revert CreatorDoesNotControlOrb();
         }
         if (auctionEndTime > 0) {

--- a/src/OrbV2.sol
+++ b/src/OrbV2.sol
@@ -193,6 +193,14 @@ contract OrbV2 is Orb {
     ///       V2 changes to allow setting parameters even during Keeper control, if Oath has expired.
     modifier onlyCreatorControlled() virtual override {
         if (address(this) != keeper && owner() != keeper && honoredUntil >= block.timestamp) {
+            // Creator CAN control Orb (does not revert) if any of these FALSE:
+            // - Orb is not held by the contract itself
+            // - Orb is not held by the creator
+            // - Oath is still honored
+            // Inverted, this means that the creator CAN control if any of these are TRUE:
+            // - Orb is held by the contract itself
+            // - Orb is held by the creator
+            // - Oath is not honored (even if Orb is held by the Keeper)
             revert CreatorDoesNotControlOrb();
         }
         if (auctionEndTime > 0) {

--- a/src/OrbV2.sol
+++ b/src/OrbV2.sol
@@ -380,7 +380,7 @@ contract OrbV2 is Orb {
     }
 
     /// @notice  Finalizes the auction, transferring the winning bid to the beneficiary, and the Orb to the winner.
-    ///          If the auction was started by previous Keeper with `relinquishWithAuction()`, then most of the auction
+    ///          If the auction was started by previous Keeper with `relinquish(true)`, then most of the auction
     ///          proceeds (minus the royalty) will be sent to the previous Keeper. Sets `lastInvocationTime` so that
     ///          the Orb could be invoked immediately. The price has been set when bidding, now becomes relevant. If no
     ///          bids were made, resets the state to allow the auction to be started again later.


### PR DESCRIPTION
_text is reworded Eric's message_

The way Orb works currently is that you swear an Oath for a certain period, and after this period is over (or even before) you can extend the honoredUntil param and after it is over you can reswear the Oath with some new params too (like different Harberger tax etc).

However, with "trial mode" (short Oath period), we realized this is not a great design. Creator will now have to auction off his Orb at trial value, and cannot get any of the auction sale value out of swearing a 10 year Oath. So we fear that this will start leading to situations where creator maybe sets the Harberger tax rate very high (because why not) and then he buys it back, and then he lowers the tax rate and does a real auction. 

The danger with this is that the person who bought the trial Orb can feel rugged. 

The new idea is to allow creator to recall the Orb after the initial trial period. This will be communicated clearly to the person who buys it in trial mode — after the trial period is up, they will lose the Orb (almost guaranteed). We did not think about this option initially, because we didn't consider that the Orb will still get traction while in trial mode. Actually some users will prefer to buy the cheap trial Orb if they have just a few questions to the creator, than having to win against long-term Orb speculators. 

In order to introduce the recall feature, a code change is necessary.

---

This commit adds `recall()` function that allows the Orb creator to transfer the Orb back to the contract after Orb Oath expires. It keeps remaining Keeper funds, allowing for withdrawal later.