### PR TITLE
OrbV3: with Minimum Price support

### DIFF
--- a/src/OrbV3.sol
+++ b/src/OrbV3.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MIT
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *
+.                                                                                                                      .
+.                                                                                                                      .
+.                                             ./         (@@@@@@@@@@@@@@@@@,                                           .
+.                                        &@@@@       /@@@@&.        *&@@@@@@@@@@*                                      .
+.                                    %@@@@@@.      (@@@                  &@@@@@@@@@&                                   .
+.                                 .@@@@@@@@       @@@                      ,@@@@@@@@@@/                                .
+.                               *@@@@@@@@@       (@%                         &@@@@@@@@@@/                              .
+.                              @@@@@@@@@@/       @@                           (@@@@@@@@@@@                             .
+.                             @@@@@@@@@@@        &@                            %@@@@@@@@@@@                            .
+.                            @@@@@@@@@@@#         @                             @@@@@@@@@@@@                           .
+.                           #@@@@@@@@@@@.                                       /@@@@@@@@@@@@                          .
+.                           @@@@@@@@@@@@                                         @@@@@@@@@@@@                          .
+.                           @@@@@@@@@@@@                                         @@@@@@@@@@@@                          .
+.                           @@@@@@@@@@@@.                                        @@@@@@@@@@@@                          .
+.                           @@@@@@@@@@@@%                                       ,@@@@@@@@@@@@                          .
+.                           ,@@@@@@@@@@@@                                       @@@@@@@@@@@@/                          .
+.                            %@@@@@@@@@@@&                                     .@@@@@@@@@@@@                           .
+.                             #@@@@@@@@@@@#                                    @@@@@@@@@@@&                            .
+.                              .@@@@@@@@@@@&                                 ,@@@@@@@@@@@,                             .
+.                                *@@@@@@@@@@@,                              @@@@@@@@@@@#                               .
+.                                   @@@@@@@@@@@*                          @@@@@@@@@@@.                                 .
+.                                     .&@@@@@@@@@@*                   .@@@@@@@@@@@.                                    .
+.                                          &@@@@@@@@@@@%*..   ..,#@@@@@@@@@@@@@*                                       .
+.                                        ,@@@@   ,#&@@@@@@@@@@@@@@@@@@#*     &@@@#                                     .
+.                                       @@@@@                                 #@@@@.                                   .
+.                                      @@@@@*                                  @@@@@,                                  .
+.                                     @@@@@@@(                               .@@@@@@@                                  .
+.                                     (@@@@@@@@@@@@@@%/*,.       ..,/#@@@@@@@@@@@@@@@                                  .
+.                                        #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@%                                     .
+.                                                ./%@@@@@@@@@@@@@@@@@@@%/,                                             .
+.                                                                                                                      .
+.                                                                                                                      .
+* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+pragma solidity 0.8.20;
+
+import {AddressUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/utils/AddressUpgradeable.sol";
+
+import {OrbV2} from "./OrbV2.sol";
+import {OrbPondV2} from "./OrbPondV2.sol";
+
+/// @title   Orb v3 - Oath-honored, Harberger-taxed NFT with built-in auction and on-chain invocations
+/// @author  Jonas Lekevicius
+/// @author  Eric Wall
+/// @notice  The Orb is issued by a Creator: the user who swore an Orb Oath together with a date until which the Oath
+///          will be honored. The Creator can list the Orb for sale at a fixed price, or run an auction for it. The user
+///          acquiring the Orb is known as the Keeper. The Keeper always has an Orb sale price set and is paying
+///          Harberger tax based on their set price and a tax rate set by the Creator. This tax is accounted for per
+///          second, and the Keeper must have enough funds on this contract to cover their ownership; otherwise the Orb
+///          is re-auctioned, delivering most of the auction proceeds to the previous Keeper. The Orb also has a
+///          cooldown that allows the Keeper to invoke the Orb — ask the Creator a question and receive their response,
+///          based on conditions set in the Orb Oath. Invocation and response hashes and timestamps are tracked in an
+///          Orb Invocation Registry.
+/// @dev     Supports ERC-721 interface, including metadata, but reverts on all transfers and approvals. Uses
+///          `Ownable`'s `owner()` to identify the Creator of the Orb. Uses a custom `UUPSUpgradeable` implementation to
+///          allow upgrades, if they are requested by the Creator and executed by the Keeper. The Orb is created as an
+///          ERC-1967 proxy to an `Orb` implementation by the `OrbPond` contract, which is also used to track allowed
+///          Orb upgrades and keeps a reference to an `OrbInvocationRegistry` used by this Orb.
+///          V2 adds these changes:
+///          - Fixes a bug with Keeper auctions changing `lastInvocationTime`. Now only creator auctions charge the Orb.
+///          - Allows setting Keeper auction royalty as different from purchase royalty.
+///          - Purchase function requires to provide Keeper auction royalty in addition to other parameters.
+///          - Response period setting moved from `swearOath` to `setCooldown` and renamed to `setInvocationParameters`.
+///          - Active Oath is now required to start Orb auction or list Orb for sale.
+///          - Orb parameters can now be updated even during Keeper control, if Oath has expired.
+///          - `beneficiaryWithdrawalAddress` can now be set by the Creator to withdraw funds to a different address, if
+///            the address is authorized on the OrbPond.
+///          - `recall()` allows Orb creator to transfer the Orb from the Keeper back to the contract, if Oath has
+///            expired, allowing for re-auctioning.
+///          - Overriden `initialize()` to allow using V2 as initial implementation, with new default values.
+///          - Event changes: `OathSwearing` parameter change, `InvocationParametersUpdate` added (replaces
+///            `CooldownUpdate` and `CleartextMaximumLengthUpdate`), `FeesUpdate` parameter change,
+///            `BeneficiaryWithdrawalAddressUpdate`, `Recall` added.
+///          V3 adds these changes:
+/// @custom:security-contact security@orb.land
+contract OrbV3 is OrbV2 {
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //  EVENTS
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    event MinimumPriceUpdate(uint256 previousMinimumPrice, uint256 indexed newMinimumPrice);
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //  ERRORS
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    error PriceTooLow(uint256 priceProvided, uint256 minimumPrice);
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //  STORAGE
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // CONSTANTS
+
+    /// Orb version. Value: 3.
+    uint256 private constant _VERSION = 3;
+
+    // STATE
+
+    /// Minimum price allowed for the Orb
+    uint256 public minimumPrice;
+
+    /// Gap used to prevent storage collisions.
+    uint256[100] private __gap;
+
+    /// @dev    When deployed, contract mints the only token that will ever exist, to itself.
+    ///         This token represents the Orb and is called the Orb elsewhere in the contract.
+    ///         `Ownable` sets the deployer to be the `owner()`, and also the creator in the Orb context.
+    ///         V2 changes initial values and sets `auctionKeeperMinimumDuration`.
+    ///         V3 just changes reinitializer value
+    /// @param  beneficiary_   Address to receive all Orb proceeds.
+    /// @param  name_          Orb name, used in ERC-721 metadata.
+    /// @param  symbol_        Orb symbol or ticker, used in ERC-721 metadata.
+    /// @param  tokenURI_      Initial value for tokenURI JSONs.
+    function initialize(address beneficiary_, string memory name_, string memory symbol_, string memory tokenURI_)
+        public
+        virtual
+        override
+        reinitializer(3)
+    {
+        __Ownable_init();
+        __UUPSUpgradeable_init();
+
+        name = name_;
+        symbol = symbol_;
+        beneficiary = beneficiary_;
+        _tokenURI = tokenURI_;
+
+        keeper = address(this);
+        pond = msg.sender;
+
+        // Initial values. Can be changed by creator before selling the Orb.
+
+        keeperTaxNumerator = 120_00;
+        purchaseRoyaltyNumerator = 10_00;
+        auctionRoyaltyNumerator = 30_00;
+
+        auctionStartingPrice = 0.05 ether;
+        auctionMinimumBidStep = 0.05 ether;
+        auctionMinimumDuration = 1 days;
+        auctionKeeperMinimumDuration = 1 days;
+        auctionBidExtension = 4 minutes;
+
+        cooldown = 7 days;
+        responsePeriod = 7 days;
+        flaggingPeriod = 7 days;
+        cleartextMaximumLength = 300;
+
+        emit Creation();
+    }
+
+    /// @notice  Re-initializes the contract after upgrade, sets initial `auctionRoyaltyNumerator` value and sets
+    ///          `responsePeriod` to `cooldown` if it was not set before.
+    function initializeV3() public reinitializer(3) {}
+
+    /// @notice  Allows the Orb creator to set minimum price Orb can be sold at. This function can only be called by the
+    ///          Orb creator when the Orb is in their control. Setting the minimum price does not adjust the current
+    ///          price, even if it's invalid: rule will apply on future Orb price settings.
+    /// @dev     Emits `FeesUpdate`.
+    ///          V3 adds this function to set the new minimum price. Setting the
+    /// @param   newMinimumPrice  New minimum price
+    function setMinimumPrice(uint256 newMinimumPrice) external virtual onlyOwner onlyCreatorControlled {
+        if (newMinimumPrice > _MAXIMUM_PRICE) {
+            revert InvalidNewPrice(newMinimumPrice);
+        }
+
+        uint256 previousMinimumPrice = minimumPrice;
+        minimumPrice = newMinimumPrice;
+
+        emit MinimumPriceUpdate(previousMinimumPrice, newMinimumPrice);
+    }
+
+    /// @dev    Does not check if the new price differs from the previous price: no risk. Limits the price to
+    ///         MAXIMUM_PRICE to prevent potential overflows in math. Confirms that the price is above `minimumPrice`.
+    ///         Emits `PriceUpdate`.
+    /// @param  newPrice_  New price for the Orb.
+    function _setPrice(uint256 newPrice_) internal virtual override {
+        if (newPrice_ > _MAXIMUM_PRICE) {
+            revert InvalidNewPrice(newPrice_);
+        }
+        if (newPrice_ < minimumPrice) {
+            revert PriceTooLow(newPrice_, minimumPrice);
+        }
+
+        uint256 previousPrice = price;
+        price = newPrice_;
+
+        emit PriceUpdate(previousPrice, newPrice_);
+    }
+
+    /// @notice  Bids the provided amount, if there's enough funds across funds on contract and transaction value.
+    ///          Might extend the auction if bidding close to auction end. Important: the leading bidder will not be
+    ///          able to withdraw any funds until someone outbids them or the auction is finalized.
+    /// @dev     Emits `AuctionBid`.
+    /// @param   amount      The value to bid.
+    /// @param   priceIfWon  Price if the bid wins. Must be less than `MAXIMUM_PRICE`.
+    function bid(uint256 amount, uint256 priceIfWon) external payable virtual override {
+        if (!_auctionRunning()) {
+            revert AuctionNotRunning();
+        }
+
+        if (msg.sender == beneficiary) {
+            revert NotPermitted();
+        }
+
+        uint256 totalFunds = fundsOf[msg.sender] + msg.value;
+
+        if (amount < _minimumBid()) {
+            revert InsufficientBid(amount, _minimumBid());
+        }
+
+        if (totalFunds < amount) {
+            revert InsufficientFunds(totalFunds, amount);
+        }
+
+        if (priceIfWon > _MAXIMUM_PRICE) {
+            revert InvalidNewPrice(priceIfWon);
+        }
+        if (priceIfWon < minimumPrice) {
+            revert PriceTooLow(priceIfWon, minimumPrice);
+        }
+
+        fundsOf[msg.sender] = totalFunds;
+        leadingBidder = msg.sender;
+        leadingBid = amount;
+        price = priceIfWon;
+
+        emit AuctionBid(msg.sender, amount);
+
+        if (block.timestamp + auctionBidExtension > auctionEndTime) {
+            auctionEndTime = block.timestamp + auctionBidExtension;
+            emit AuctionExtension(auctionEndTime);
+        }
+    }
+
+    /// @notice  Returns the version of the Orb. Internal constant `_VERSION` will be increased with each upgrade.
+    /// @return  orbVersion  Version of the Orb.
+    function version() public view virtual override returns (uint256 orbVersion) {
+        return _VERSION;
+    }
+}

--- a/src/test-upgrades/OrbTestUpgrade.sol
+++ b/src/test-upgrades/OrbTestUpgrade.sol
@@ -35,7 +35,7 @@
 * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 pragma solidity 0.8.20;
 
-import {OrbV2} from "../OrbV2.sol";
+import {OrbV3} from "../OrbV3.sol";
 
 /// @title   Orb Test Upgrade - Oath-honored, Harberger-taxed NFT with built-in auction and on-chain invocations
 /// @author  Jonas Lekevicius
@@ -56,7 +56,7 @@ import {OrbV2} from "../OrbV2.sol";
 ///          Orb upgrades and keeps a reference to an `OrbInvocationRegistry` used by this Orb.
 ///          Test Upgrade adds a new storage variable `number`, settable with `setNumber`, changes Orb name and symbol,
 ///          and allows the Creator to set the cleartext maximum length to zero. FOR TESTING ONLY!
-contract OrbTestUpgrade is OrbV2 {
+contract OrbTestUpgrade is OrbV3 {
     /// Orb version.
     uint256 private constant _VERSION = 100;
 

--- a/test/OrbV3/OrbV3-Auction.t.sol
+++ b/test/OrbV3/OrbV3-Auction.t.sol
@@ -1,0 +1,493 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {Test} from "../../lib/forge-std/src/Test.sol";
+
+import {OrbTestBase} from "./OrbV3.t.sol";
+import {Orb} from "../../src/Orb.sol";
+import {OrbV2} from "../../src/OrbV2.sol";
+import {OrbV3} from "../../src/OrbV3.sol";
+
+/* solhint-disable func-name-mixedcase,private-vars-leading-underscore */
+contract MinimumBidTest is OrbTestBase {
+    function test_minimumBidReturnsCorrectValues() public {
+        uint256 bidAmount = 0.6 ether;
+        orb.startAuction();
+        assertEq(orb.workaround_minimumBid(), orb.auctionStartingPrice());
+        prankAndBid(user, bidAmount);
+        assertEq(orb.workaround_minimumBid(), bidAmount + orb.auctionMinimumBidStep());
+    }
+}
+
+contract StartAuctionTest is OrbTestBase {
+    function test_startAuctionOnlyOrbCreator() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert("Ownable: caller is not the owner");
+        orb.startAuction();
+    }
+
+    function test_revertsIfOathNotSworn() public {
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 0);
+        vm.expectRevert(OrbV2.NotHonored.selector);
+        orb.startAuction();
+    }
+
+    event AuctionStart(
+        uint256 indexed auctionStartTime, uint256 indexed auctionEndTime, address indexed auctionBeneficiary
+    );
+
+    function test_startAuctionCorrectly() public {
+        vm.expectEmit(true, true, true, true);
+        emit AuctionStart(block.timestamp, block.timestamp + orb.auctionMinimumDuration(), beneficiary);
+        orb.startAuction();
+        assertEq(orb.auctionEndTime(), block.timestamp + orb.auctionMinimumDuration());
+        assertEq(orb.leadingBid(), 0);
+        assertEq(orb.leadingBidder(), address(0));
+    }
+
+    function test_startAuctionOnlyContractHeld() public {
+        orb.workaround_setOrbKeeper(address(0xBEEF));
+        vm.expectRevert(Orb.ContractDoesNotHoldOrb.selector);
+        orb.startAuction();
+        orb.workaround_setOrbKeeper(address(orb));
+        vm.expectEmit(true, true, true, true);
+        emit AuctionStart(block.timestamp, block.timestamp + orb.auctionMinimumDuration(), beneficiary);
+        orb.startAuction();
+    }
+
+    function test_startAuctionNotDuringAuction() public {
+        assertEq(orb.auctionEndTime(), 0);
+        vm.expectEmit(true, true, true, true);
+        emit AuctionStart(block.timestamp, block.timestamp + orb.auctionMinimumDuration(), beneficiary);
+        orb.startAuction();
+        assertGt(orb.auctionEndTime(), 0);
+        vm.warp(orb.auctionEndTime());
+
+        vm.expectRevert(Orb.AuctionRunning.selector);
+        orb.startAuction();
+    }
+}
+
+contract BidTest is OrbTestBase {
+    function test_bidOnlyDuringAuction() public {
+        uint256 bidAmount = 0.6 ether;
+        vm.deal(user, bidAmount);
+        vm.expectRevert(Orb.AuctionNotRunning.selector);
+        vm.prank(user);
+        orb.bid{value: bidAmount}(bidAmount, bidAmount);
+        orb.startAuction();
+        assertEq(orb.leadingBid(), 0 ether);
+        prankAndBid(user, bidAmount);
+        assertEq(orb.leadingBid(), bidAmount);
+    }
+
+    function test_bidUsesTotalFunds() public {
+        orb.deposit{value: 1 ether}();
+        orb.startAuction();
+        vm.prank(user);
+        assertEq(orb.leadingBid(), 0 ether);
+        prankAndBid(user, 0.5 ether);
+        assertEq(orb.leadingBid(), 0.5 ether);
+    }
+
+    function test_bidRevertsIfBeneficiary() public {
+        orb.startAuction();
+        uint256 amount = orb.workaround_minimumBid();
+        vm.deal(beneficiary, amount);
+        vm.expectRevert(abi.encodeWithSelector(Orb.NotPermitted.selector));
+        vm.prank(beneficiary);
+        orb.bid{value: amount}(amount, amount);
+
+        // will not revert
+        prankAndBid(user, amount);
+        assertEq(orb.leadingBid(), amount);
+    }
+
+    function test_bidRevertsIfLtMinimumBid() public {
+        orb.startAuction();
+        // minimum bid will be the STARTING_PRICE
+        uint256 amount = orb.workaround_minimumBid() - 1;
+        vm.expectRevert(abi.encodeWithSelector(Orb.InsufficientBid.selector, amount, orb.workaround_minimumBid()));
+        vm.prank(user);
+        orb.bid{value: amount}(amount, amount);
+
+        // Add back + 1 to amount
+        amount++;
+        // will not revert
+        vm.prank(user);
+        orb.bid{value: amount}(amount, amount);
+        assertEq(orb.leadingBid(), amount);
+
+        // minimum bid will be the leading bid + MINIMUM_BID_STEP
+        amount = orb.workaround_minimumBid() - 1;
+        vm.expectRevert(abi.encodeWithSelector(Orb.InsufficientBid.selector, amount, orb.workaround_minimumBid()));
+        vm.prank(user);
+        orb.bid{value: amount}(amount, amount);
+    }
+
+    function test_bidRevertsIfLtFundsRequired() public {
+        orb.startAuction();
+        uint256 amount = orb.workaround_minimumBid();
+        uint256 funds = amount - 1;
+        vm.expectRevert(abi.encodeWithSelector(Orb.InsufficientFunds.selector, funds, funds + 1));
+        vm.prank(user);
+        orb.bid{value: funds}(amount, amount);
+
+        funds++;
+        vm.prank(user);
+        // will not revert
+        orb.bid{value: funds}(amount, amount);
+        assertEq(orb.leadingBid(), amount);
+    }
+
+    function test_bidRevertsIfPriceTooLow() public {
+        uint256 minimumPrice = 10 ether;
+        orb.setMinimumPrice(minimumPrice);
+        orb.startAuction();
+        uint256 amount = orb.workaround_minimumBid();
+        uint256 price = minimumPrice - 1;
+        vm.expectRevert(abi.encodeWithSelector(OrbV3.PriceTooLow.selector, price, minimumPrice));
+        vm.prank(user);
+        orb.bid{value: amount}(amount, price);
+
+        // Bring price back to acceptable amount
+        price = minimumPrice;
+        // will not revert
+        vm.prank(user);
+        orb.bid{value: amount}(amount, price);
+        assertEq(orb.leadingBid(), amount);
+        assertEq(orb.price(), orb.minimumPrice());
+    }
+
+    function test_bidRevertsIfPriceTooHigh() public {
+        orb.startAuction();
+        uint256 amount = orb.workaround_minimumBid();
+        uint256 price = orb.workaround_maximumPrice() + 1;
+        vm.expectRevert(abi.encodeWithSelector(Orb.InvalidNewPrice.selector, price));
+        vm.prank(user);
+        orb.bid{value: amount}(amount, price);
+
+        // Bring price back to acceptable amount
+        price--;
+        // will not revert
+        vm.prank(user);
+        orb.bid{value: amount}(amount, price);
+        assertEq(orb.leadingBid(), amount);
+        assertEq(orb.price(), orb.workaround_maximumPrice());
+    }
+
+    event AuctionBid(address indexed bidder, uint256 indexed bid);
+
+    function test_bidSetsCorrectState() public {
+        orb.startAuction();
+        uint256 amount = orb.workaround_minimumBid();
+        uint256 funds = fundsRequiredToBidOneYear(amount);
+        assertEq(orb.leadingBid(), 0 ether);
+        assertEq(orb.leadingBidder(), address(0));
+        assertEq(orb.fundsOf(user), 0);
+        assertEq(address(orb).balance, 0);
+        uint256 auctionEndTime = orb.auctionEndTime();
+
+        vm.expectEmit(true, true, true, true);
+        emit AuctionBid(user, amount);
+        prankAndBid(user, amount);
+
+        assertEq(orb.leadingBid(), amount);
+        assertEq(orb.leadingBidder(), user);
+        assertEq(orb.price(), amount);
+        assertEq(orb.fundsOf(user), funds);
+        assertEq(address(orb).balance, funds);
+        assertEq(orb.auctionEndTime(), auctionEndTime);
+    }
+
+    mapping(address => uint256) internal fundsOfUser;
+
+    event AuctionFinalization(address indexed winner, uint256 indexed winningBid);
+
+    function testFuzz_bidSetsCorrectState(address[16] memory bidders, uint128[16] memory amounts) public {
+        orb.startAuction();
+        uint256 contractBalance;
+        for (uint256 i = 1; i < 16; i++) {
+            uint256 upperBound = orb.workaround_minimumBid() + 1_000_000_000;
+            uint256 amount = bound(amounts[i], orb.workaround_minimumBid(), upperBound);
+            address bidder = bidders[i];
+            vm.assume(bidder != address(0) && bidder != address(orb) && bidder != beneficiary);
+
+            uint256 funds = fundsRequiredToBidOneYear(amount);
+
+            fundsOfUser[bidder] += funds;
+
+            vm.expectEmit(true, true, true, true);
+            emit AuctionBid(bidder, amount);
+            prankAndBid(bidder, amount);
+            contractBalance += funds;
+
+            assertEq(orb.leadingBid(), amount);
+            assertEq(orb.leadingBidder(), bidder);
+            assertEq(orb.price(), amount);
+            assertEq(orb.fundsOf(bidder), fundsOfUser[bidder]);
+            assertEq(address(orb).balance, contractBalance);
+        }
+        vm.expectEmit(true, true, true, true);
+        emit AuctionFinalization(orb.leadingBidder(), orb.leadingBid());
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+    }
+
+    event AuctionExtension(uint256 indexed newAuctionEndTime);
+
+    function test_bidExtendsAuction() public {
+        assertEq(orb.auctionEndTime(), 0);
+        orb.startAuction();
+        uint256 amount = orb.workaround_minimumBid();
+        // auctionEndTime = block.timestamp + auctionMinimumDuration
+        uint256 auctionEndTime = orb.auctionEndTime();
+        // set block.timestamp to auctionEndTime - auctionBidExtension
+        vm.warp(auctionEndTime - orb.auctionBidExtension());
+        prankAndBid(user, amount);
+        // didn't change because block.timestamp + auctionBidExtension = auctionEndTime
+        assertEq(orb.auctionEndTime(), auctionEndTime);
+
+        vm.warp(auctionEndTime - orb.auctionBidExtension() + 50);
+        amount = orb.workaround_minimumBid();
+        vm.expectEmit(true, true, true, true);
+        emit AuctionExtension(auctionEndTime + 50);
+        prankAndBid(user, amount);
+        // change because block.timestamp + auctionBidExtension + 50 >  auctionEndTime
+        assertEq(orb.auctionEndTime(), auctionEndTime + 50);
+    }
+}
+
+contract FinalizeAuctionTest is OrbTestBase {
+    event AuctionFinalization(address indexed winner, uint256 indexed winningBid);
+
+    function test_finalizeAuctionRevertsDuringAuction() public {
+        orb.startAuction();
+        vm.expectRevert(Orb.AuctionRunning.selector);
+        orb.finalizeAuction();
+
+        vm.warp(orb.auctionEndTime() + 1);
+        vm.expectEmit(true, true, true, true);
+        emit AuctionFinalization(address(0), 0);
+        orb.finalizeAuction();
+    }
+
+    function test_finalizeAuctionRevertsIfAuctionNotStarted() public {
+        vm.expectRevert(Orb.AuctionNotStarted.selector);
+        orb.finalizeAuction();
+        orb.startAuction();
+        // auctionEndTime != 0
+        assertEq(orb.auctionEndTime(), block.timestamp + orb.auctionMinimumDuration());
+        vm.expectRevert(Orb.AuctionRunning.selector);
+        orb.finalizeAuction();
+    }
+
+    function test_finalizeAuctionWithoutWinner() public {
+        orb.startAuction();
+        vm.warp(orb.auctionEndTime() + 1);
+        vm.expectEmit(true, true, true, true);
+        emit AuctionFinalization(address(0), 0);
+        orb.finalizeAuction();
+        assertEq(orb.auctionEndTime(), 0);
+        assertEq(orb.leadingBid(), 0);
+        assertEq(orb.leadingBidder(), address(0));
+        assertEq(orb.price(), 0);
+    }
+
+    event PriceUpdate(uint256 previousPrice, uint256 indexed newPrice);
+
+    function test_finalizeAuctionWithWinner() public {
+        orb.startAuction();
+        uint256 amount = orb.workaround_minimumBid();
+        uint256 funds = fundsRequiredToBidOneYear(amount);
+        // Bid `amount` and transfer `funds` to the contract
+        prankAndBid(user, amount);
+        vm.warp(orb.auctionEndTime() + 1);
+
+        // Assert storage before
+        assertEq(orb.leadingBidder(), user);
+        assertEq(orb.leadingBid(), amount);
+        assertEq(orb.price(), amount);
+        assertEq(orb.fundsOf(user), funds);
+        assertEq(orb.fundsOf(address(orb)), 0);
+
+        vm.expectEmit(true, true, true, true);
+        emit AuctionFinalization(user, amount);
+        vm.expectEmit(true, true, true, true);
+        emit PriceUpdate(0, amount);
+
+        orb.finalizeAuction();
+
+        // Assert storage after
+        // storage that is reset
+        assertEq(orb.auctionEndTime(), 0);
+        assertEq(orb.leadingBid(), 0);
+        assertEq(orb.leadingBidder(), address(0));
+        assertEq(orb.price(), amount);
+
+        // storage that persists
+        assertEq(address(orb).balance, funds);
+        assertEq(orb.fundsOf(beneficiary), amount);
+        assertEq(orb.keeper(), user);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(orb.lastInvocationTime(), block.timestamp - orb.cooldown());
+        assertEq(orb.fundsOf(user), funds - amount);
+        assertEq(orb.price(), amount);
+    }
+
+    function test_finalizeAuctionWithBeneficiary() public {
+        makeKeeperAndWarp(user, 1 ether);
+        assertEq(orb.auctionBeneficiary(), beneficiary);
+        vm.prank(user);
+        orb.relinquish(true);
+        uint256 contractBalance = address(orb).balance;
+        assertEq(orb.auctionBeneficiary(), user);
+
+        uint256 amount = orb.workaround_minimumBid();
+        uint256 funds = fundsRequiredToBidOneYear(amount);
+        // Bid `amount` and transfer `funds` to the contract
+        prankAndBid(user2, amount);
+        vm.warp(orb.auctionEndTime() + 1);
+
+        // Assert storage before
+        assertEq(orb.leadingBidder(), user2);
+        assertEq(orb.leadingBid(), amount);
+        assertEq(orb.price(), amount);
+        assertEq(orb.fundsOf(user2), funds);
+        assertEq(orb.fundsOf(address(orb)), 0);
+
+        uint256 beneficiaryRoyalty = (amount * orb.auctionRoyaltyNumerator()) / orb.feeDenominator();
+        uint256 auctionBeneficiaryShare = amount - beneficiaryRoyalty;
+        uint256 userFunds = orb.fundsOf(user);
+        uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
+        uint256 lastInvocationTime = orb.lastInvocationTime();
+
+        vm.expectEmit(true, true, true, true);
+        emit AuctionFinalization(user2, amount);
+        vm.expectEmit(true, true, true, true);
+        emit PriceUpdate(0, amount);
+
+        orb.finalizeAuction();
+
+        // Assert storage after
+        // storage that is reset
+        assertEq(orb.auctionEndTime(), 0);
+        assertEq(orb.leadingBid(), 0);
+        assertEq(orb.leadingBidder(), address(0));
+        assertEq(orb.price(), amount);
+
+        // storage that persists
+        assertEq(address(orb).balance, contractBalance + funds);
+        assertEq(orb.fundsOf(beneficiary), beneficiaryFunds + beneficiaryRoyalty);
+        assertEq(orb.keeper(), user2);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(orb.lastInvocationTime(), lastInvocationTime); // unchanged because it's Keeper's auction
+        assertEq(orb.fundsOf(user2), funds - amount);
+        assertEq(orb.fundsOf(user), userFunds + auctionBeneficiaryShare);
+    }
+
+    function test_finalizeAuctionWithBeneficiaryLowRoyalties() public {
+        orb.setFees(100_00, 100_00, 0);
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(user);
+        orb.relinquish(true);
+        uint256 amount = orb.workaround_minimumBid();
+        // Bid `amount` and transfer `funds` to the contract
+        prankAndBid(user2, amount);
+        vm.warp(orb.auctionEndTime() + 1);
+        uint256 minBeneficiaryNumerator =
+            orb.keeperTaxNumerator() * orb.auctionKeeperMinimumDuration() / orb.keeperTaxPeriod();
+        assertTrue(minBeneficiaryNumerator > orb.auctionRoyaltyNumerator());
+        uint256 minBeneficiaryRoyalty = (amount * minBeneficiaryNumerator) / orb.feeDenominator();
+        uint256 auctionBeneficiaryShare = amount - minBeneficiaryRoyalty;
+        uint256 userFunds = orb.fundsOf(user);
+        uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
+        orb.finalizeAuction();
+        assertEq(orb.fundsOf(beneficiary), beneficiaryFunds + minBeneficiaryRoyalty);
+        assertEq(orb.fundsOf(user), userFunds + auctionBeneficiaryShare);
+    }
+
+    function test_finalizeAuctionWithBeneficiaryWithoutWinner() public {
+        makeKeeperAndWarp(user, 1 ether);
+        assertEq(orb.auctionBeneficiary(), beneficiary);
+        vm.prank(user);
+        orb.relinquish(true);
+        assertEq(orb.auctionBeneficiary(), user);
+        vm.warp(orb.auctionEndTime() + 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit AuctionFinalization(address(0), 0);
+        orb.finalizeAuction();
+
+        // Assert storage after
+        assertEq(orb.auctionBeneficiary(), user);
+        assertEq(orb.auctionEndTime(), 0);
+        assertEq(orb.leadingBid(), 0);
+        assertEq(orb.leadingBidder(), address(0));
+        assertEq(orb.price(), 0);
+
+        orb.startAuction();
+        assertEq(orb.auctionBeneficiary(), beneficiary);
+    }
+}
+
+contract ListingTest is OrbTestBase {
+    function test_revertsIfOathNotSworn() public {
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 0);
+        vm.expectRevert(OrbV2.NotHonored.selector);
+        orb.listWithPrice(1 ether);
+    }
+
+    function test_revertsIfHeldByUser() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.expectRevert(Orb.ContractDoesNotHoldOrb.selector);
+        orb.listWithPrice(1 ether);
+    }
+
+    function test_revertsIfAlreadyHeldByCreator() public {
+        makeKeeperAndWarp(owner, 1 ether);
+        vm.expectRevert(Orb.ContractDoesNotHoldOrb.selector);
+        orb.listWithPrice(1 ether);
+    }
+
+    function test_revertsIfAuctionStarted() public {
+        orb.startAuction();
+        vm.expectRevert(Orb.AuctionRunning.selector);
+        orb.listWithPrice(1 ether);
+
+        vm.warp(orb.auctionEndTime() + 1);
+        assertFalse(orb.workaround_auctionRunning());
+        vm.expectRevert(Orb.AuctionRunning.selector);
+        orb.listWithPrice(1 ether);
+    }
+
+    function test_revertsIfCalledByUser() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(user);
+        orb.listWithPrice(1 ether);
+    }
+
+    function test_revertsIfPriceTooLow() public {
+        uint256 minimumPrice = 10 ether;
+        orb.setMinimumPrice(minimumPrice);
+        assertEq(orb.minimumPrice(), minimumPrice);
+        uint256 price = minimumPrice - 1;
+        vm.expectRevert(abi.encodeWithSelector(OrbV3.PriceTooLow.selector, price, minimumPrice));
+        orb.listWithPrice(price);
+    }
+
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event PriceUpdate(uint256 previousPrice, uint256 indexed newPrice);
+
+    function test_succeedsCorrectly() public {
+        uint256 listingPrice = 1 ether;
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(orb), owner, 1);
+        vm.expectEmit(true, true, true, true);
+        emit PriceUpdate(0, listingPrice);
+        orb.listWithPrice(listingPrice);
+        assertEq(orb.price(), listingPrice);
+        assertEq(orb.keeper(), owner);
+    }
+}

--- a/test/OrbV3/OrbV3-Forfeit.t.sol
+++ b/test/OrbV3/OrbV3-Forfeit.t.sol
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {Test} from "../../lib/forge-std/src/Test.sol";
+
+import {OrbTestBase} from "./OrbV3.t.sol";
+import {Orb} from "../../src/Orb.sol";
+import {OrbV2} from "../../src/OrbV2.sol";
+
+/* solhint-disable func-name-mixedcase */
+contract RelinquishmentTest is OrbTestBase {
+    function test_revertsIfNotKeeper() public {
+        uint256 leadingBid = 10 ether;
+        makeKeeperAndWarp(user, leadingBid);
+        vm.expectRevert(Orb.NotKeeper.selector);
+        vm.prank(user2);
+        orb.relinquish(false);
+
+        vm.prank(user);
+        orb.relinquish(false);
+        assertEq(orb.keeper(), address(orb));
+    }
+
+    function test_revertsIfKeeperInsolvent() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.warp(block.timestamp + 1300 days);
+        vm.prank(user);
+        vm.expectRevert(Orb.KeeperInsolvent.selector);
+        orb.relinquish(false);
+        vm.warp(block.timestamp - 1300 days);
+        vm.prank(user);
+        orb.relinquish(false);
+        assertEq(orb.keeper(), address(orb));
+    }
+
+    function test_settlesFirst() public {
+        makeKeeperAndWarp(user, 1 ether);
+        // after making `user` the current keeper of the Orb, `makeKeeperAndWarp(user, )` warps 30 days into the future
+        assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
+        vm.prank(user);
+        orb.relinquish(false);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+    }
+
+    event Relinquishment(address indexed formerKeeper);
+    event Withdrawal(address indexed recipient, uint256 indexed amount);
+
+    function test_succeedsCorrectly() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(user);
+        assertEq(orb.keeper(), user);
+        vm.expectEmit(true, true, true, true);
+        emit Relinquishment(user);
+        vm.expectEmit(true, true, true, true);
+        uint256 effectiveFunds = effectiveFundsOf(user);
+        emit Withdrawal(user, effectiveFunds);
+        vm.prank(user);
+        orb.relinquish(false);
+        assertEq(orb.keeper(), address(orb));
+        assertEq(orb.price(), 0);
+    }
+}
+
+contract RelinquishmentWithAuctionTest is OrbTestBase {
+    function test_revertsIfNotKeeper() public {
+        uint256 leadingBid = 10 ether;
+        makeKeeperAndWarp(user, leadingBid);
+        vm.expectRevert(Orb.NotKeeper.selector);
+        vm.prank(user2);
+        orb.relinquish(true);
+
+        vm.prank(user);
+        orb.relinquish(true);
+        assertEq(orb.keeper(), address(orb));
+    }
+
+    function test_revertsIfKeeperInsolvent() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.warp(block.timestamp + 1300 days);
+        vm.prank(user);
+        vm.expectRevert(Orb.KeeperInsolvent.selector);
+        orb.relinquish(true);
+        vm.warp(block.timestamp - 1300 days);
+        vm.prank(user);
+        orb.relinquish(true);
+        assertEq(orb.keeper(), address(orb));
+    }
+
+    function test_revertsIfCreator() public {
+        orb.listWithPrice(1 ether);
+        vm.expectRevert(Orb.NotPermitted.selector);
+        orb.relinquish(true);
+    }
+
+    function test_noAuctionIfKeeperDurationZero() public {
+        orb.setAuctionParameters(0, 1, 1 days, 0, 5 minutes);
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(user);
+        orb.relinquish(true);
+        assertEq(orb.auctionEndTime(), 0);
+    }
+
+    function test_settlesFirst() public {
+        makeKeeperAndWarp(user, 1 ether);
+        // after making `user` the current keeper of the Orb, `makeKeeperAndWarp(user, )` warps 30 days into the future
+        assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
+        vm.prank(user);
+        orb.relinquish(true);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+    }
+
+    event Relinquishment(address indexed formerKeeper);
+    event AuctionStart(
+        uint256 indexed auctionStartTime, uint256 indexed auctionEndTime, address indexed auctionBeneficiary
+    );
+    event Withdrawal(address indexed recipient, uint256 indexed amount);
+
+    function test_succeedsCorrectly() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(user);
+        assertEq(orb.keeper(), user);
+        assertEq(orb.price(), 1 ether);
+        assertEq(orb.auctionBeneficiary(), beneficiary);
+        assertEq(orb.auctionEndTime(), 0);
+        uint256 effectiveFunds = effectiveFundsOf(user);
+        vm.expectEmit(true, true, true, true);
+        emit Relinquishment(user);
+        vm.expectEmit(true, true, true, true);
+        emit AuctionStart(block.timestamp, block.timestamp + orb.auctionKeeperMinimumDuration(), user);
+        vm.expectEmit(true, true, true, true);
+        emit Withdrawal(user, effectiveFunds);
+        vm.prank(user);
+        orb.relinquish(true);
+        assertEq(orb.keeper(), address(orb));
+        assertEq(orb.price(), 0);
+        assertEq(orb.auctionBeneficiary(), user);
+        assertEq(orb.auctionEndTime(), block.timestamp + orb.auctionKeeperMinimumDuration());
+    }
+}
+
+contract ForecloseTest is OrbTestBase {
+    function test_revertsIfNotKeeperHeld() public {
+        vm.expectRevert(Orb.ContractHoldsOrb.selector);
+        vm.prank(user2);
+        orb.foreclose();
+
+        uint256 leadingBid = 10 ether;
+        makeKeeperAndWarp(user, leadingBid);
+        vm.warp(block.timestamp + 100000 days);
+        vm.prank(user2);
+        orb.foreclose();
+        assertEq(orb.keeper(), address(orb));
+    }
+
+    event Foreclosure(address indexed formerKeeper);
+    event AuctionStart(
+        uint256 indexed auctionStartTime, uint256 indexed auctionEndTime, address indexed auctionBeneficiary
+    );
+
+    function test_revertsifKeeperSolvent() public {
+        uint256 leadingBid = 10 ether;
+        makeKeeperAndWarp(user, leadingBid);
+        vm.expectRevert(Orb.KeeperSolvent.selector);
+        orb.foreclose();
+        vm.warp(block.timestamp + 10000 days);
+        vm.expectEmit(true, true, true, true);
+        emit Foreclosure(user);
+        orb.foreclose();
+    }
+
+    function test_noAuctionIfKeeperDurationZero() public {
+        orb.setAuctionParameters(0, 1, 1 days, 0, 5 minutes);
+        makeKeeperAndWarp(user, 10 ether);
+        vm.warp(block.timestamp + 10000 days);
+        vm.expectEmit(true, true, true, true);
+        emit Foreclosure(user);
+        assertEq(orb.keeper(), user);
+        orb.foreclose();
+        assertEq(orb.auctionEndTime(), 0);
+        assertEq(orb.keeper(), address(orb));
+        assertEq(orb.price(), 0);
+    }
+
+    function test_succeeds() public {
+        makeKeeperAndWarp(user, 10 ether);
+        vm.warp(block.timestamp + 10000 days);
+        uint256 exepectedEndTime = block.timestamp + orb.auctionKeeperMinimumDuration();
+        vm.expectEmit(true, true, true, true);
+        emit Foreclosure(user);
+        vm.expectEmit(true, true, true, true);
+        emit AuctionStart(block.timestamp, exepectedEndTime, user);
+        assertEq(orb.keeper(), user);
+        orb.foreclose();
+        assertEq(orb.auctionBeneficiary(), user);
+        assertEq(orb.auctionEndTime(), exepectedEndTime);
+        assertEq(orb.keeper(), address(orb));
+        assertEq(orb.price(), 0);
+    }
+}
+
+contract RecallTest is OrbTestBase {
+    event Recall(address indexed formerKeeper);
+
+    function test_revertsWhenNotOwner() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(user);
+        orb.recall();
+    }
+
+    function test_revertsIfNotKeeperHeld() public {
+        vm.expectRevert(OrbV2.KeeperDoesNotHoldOrb.selector);
+        orb.recall();
+
+        orb.listWithPrice(1 ether);
+        vm.expectRevert(OrbV2.KeeperDoesNotHoldOrb.selector);
+        orb.recall();
+    }
+
+    function test_revertsIfOathHonored() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.expectRevert(OrbV2.OathStillHonored.selector);
+        orb.recall();
+
+        vm.warp(20_000_000);
+        vm.expectRevert(OrbV2.OathStillHonored.selector);
+        orb.recall();
+
+        vm.warp(20_000_001);
+        vm.expectEmit(true, true, true, true);
+        emit Recall(user);
+        orb.recall();
+    }
+
+    event Settlement(address indexed keeper, address indexed beneficiary, uint256 indexed amount);
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    function test_succeeds() public {
+        makeKeeperAndWarp(user, 10 ether);
+        vm.warp(20_000_001);
+
+        assertEq(orb.lastSettlementTime(), 10_086_401); // 10M + 1 day + 1
+        assertEq(orb.keeper(), user);
+        assertEq(orb.price(), 10 ether);
+
+        uint256 owed = orb.workaround_owedSinceLastSettlement();
+
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, owed);
+        vm.expectEmit(true, true, true, true);
+        emit Recall(user);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(user, address(orb), 1);
+
+        orb.recall();
+
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(orb.keeper(), address(orb));
+        assertEq(orb.price(), 0);
+    }
+}

--- a/test/OrbV3/OrbV3-Funding.t.sol
+++ b/test/OrbV3/OrbV3-Funding.t.sol
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {Test} from "../../lib/forge-std/src/Test.sol";
+
+import {OrbTestBase} from "./OrbV3.t.sol";
+import {Orb} from "../../src/Orb.sol";
+
+/* solhint-disable func-name-mixedcase */
+contract EffectiveFundsOfTest is OrbTestBase {
+    function test_effectiveFundsCorrectCalculation() public {
+        uint256 amount1 = 1 ether;
+        uint256 amount2 = 0.5 ether;
+        uint256 funds1 = fundsRequiredToBidOneYear(amount1);
+        uint256 funds2 = fundsRequiredToBidOneYear(amount2);
+        orb.startAuction();
+        prankAndBid(user2, amount2);
+        prankAndBid(user, amount1);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 1 days);
+
+        // One day has passed since the Orb keeper got the orb
+        // for bid = 1 ether. That means that the price of the
+        // Orb is now 1 ether. Thus the Orb beneficiary is owed the tax
+        // for 1 day.
+
+        // The user actually transfered `funds1` and `funds2` respectively
+        // ether to the contract
+        uint256 owed = orb.workaround_owedSinceLastSettlement();
+        assertEq(effectiveFundsOf(beneficiary), owed + amount1);
+        // The user that won the auction and is holding the orb
+        // has the funds they deposited, minus the tax and minus the bid
+        // amount
+        assertEq(effectiveFundsOf(user), funds1 - owed - amount1);
+        // The user that didn't won the auction, has the funds they
+        // deposited
+        assertEq(effectiveFundsOf(user2), funds2);
+    }
+
+    function testFuzz_effectiveFundsCorrectCalculation(uint256 amount1, uint256 amount2) public {
+        amount1 = bound(amount1, 1 ether, orb.workaround_maximumPrice());
+        amount2 = bound(amount2, orb.auctionStartingPrice(), amount1 - orb.auctionMinimumBidStep());
+        uint256 funds1 = fundsRequiredToBidOneYear(amount1);
+        uint256 funds2 = fundsRequiredToBidOneYear(amount2);
+        orb.startAuction();
+        prankAndBid(user2, amount2);
+        prankAndBid(user, amount1);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 1 days);
+
+        // One day has passed since the Orb keeper got the Orb
+        // for bid = 1 ether. That means that the price of the
+        // Orb is now 1 ether. Thus the Orb beneficiary is owed the tax
+        // for 1 day.
+
+        // The user actually transfered `funds1` and `funds2` respectively
+        // ether to the contract
+        uint256 owed = orb.workaround_owedSinceLastSettlement();
+        assertEq(effectiveFundsOf(beneficiary), owed + amount1);
+        // The user that won the auction and is holding the Orb
+        // has the funds they deposited, minus the tax and minus the bid
+        // amount
+        assertEq(effectiveFundsOf(user), funds1 - owed - amount1);
+        // The user that didn't won the auction, has the funds they
+        // deposited
+        assertEq(effectiveFundsOf(user2), funds2);
+    }
+}
+
+contract DepositTest is OrbTestBase {
+    event Deposit(address indexed depositor, uint256 indexed amount);
+
+    function test_depositRandomUser() public {
+        assertEq(orb.fundsOf(user), 0);
+        vm.expectEmit(true, true, true, true);
+        emit Deposit(user, 1 ether);
+        vm.prank(user);
+        orb.deposit{value: 1 ether}();
+        assertEq(orb.fundsOf(user), 1 ether);
+    }
+
+    function testFuzz_depositRandomUser(uint256 amount) public {
+        assertEq(orb.fundsOf(user), 0);
+        vm.expectEmit(true, true, true, true);
+        emit Deposit(user, amount);
+        vm.deal(user, amount);
+        vm.prank(user);
+        orb.deposit{value: amount}();
+        assertEq(orb.fundsOf(user), amount);
+    }
+
+    function test_depositKeeperSolvent() public {
+        assertEq(orb.fundsOf(user), 0);
+        // winning bid  = 1 ether
+        uint256 bidAmount = 1 ether;
+        uint256 depositAmount = 2 ether;
+        makeKeeperAndWarp(user, bidAmount);
+        // User bids 1 ether, but deposit enough funds
+        // to cover the tax for a year, according to
+        // fundsRequiredToBidOneYear(bidAmount)
+        uint256 funds = orb.fundsOf(user);
+        vm.expectEmit(true, true, true, true);
+        // deposit 1 ether
+        emit Deposit(user, depositAmount);
+        vm.prank(user);
+        orb.deposit{value: depositAmount}();
+        assertEq(orb.fundsOf(user), funds + depositAmount);
+    }
+
+    function testFuzz_depositKeeperSolvent(uint256 bidAmount, uint256 depositAmount) public {
+        assertEq(orb.fundsOf(user), 0);
+        // winning bid  = 1 ether
+        bidAmount = bound(bidAmount, 0.1 ether, orb.workaround_maximumPrice());
+        depositAmount = bound(depositAmount, 0.1 ether, orb.workaround_maximumPrice());
+        makeKeeperAndWarp(user, bidAmount);
+        // User bids 1 ether, but deposit enough funds
+        // to cover the tax for a year, according to
+        // fundsRequiredToBidOneYear(bidAmount)
+        uint256 funds = orb.fundsOf(user);
+        vm.expectEmit(true, true, true, true);
+        // deposit 1 ether
+        emit Deposit(user, depositAmount);
+        vm.prank(user);
+        vm.deal(user, depositAmount);
+        orb.deposit{value: depositAmount}();
+        assertEq(orb.fundsOf(user), funds + depositAmount);
+    }
+
+    function test_depositRevertsifKeeperInsolvent() public {
+        assertEq(orb.fundsOf(user), 0);
+        // winning bid  = 1 ether
+        uint256 bidAmount = 1 ether;
+        makeKeeperAndWarp(user, bidAmount);
+
+        // let's make the user insolvent
+        // fundsRequiredToBidOneYear(bidAmount) ensures enough
+        // ether for 1 year, not two
+        vm.warp(block.timestamp + 731 days);
+
+        // if a random user deposits, it should work fine
+        vm.prank(user2);
+        orb.deposit{value: 1 ether}();
+        assertEq(orb.fundsOf(user2), 1 ether);
+
+        // if the insolvent keeper deposits, it should not work
+        vm.expectRevert(Orb.KeeperInsolvent.selector);
+        vm.prank(user);
+        orb.deposit{value: 1 ether}();
+    }
+}
+
+contract WithdrawTest is OrbTestBase {
+    event Withdrawal(address indexed recipient, uint256 indexed amount);
+
+    function test_withdrawRevertsIfLeadingBidder() public {
+        uint256 bidAmount = 1 ether;
+        orb.startAuction();
+        prankAndBid(user, bidAmount);
+        vm.expectRevert(Orb.NotPermittedForLeadingBidder.selector);
+        vm.prank(user);
+        orb.withdraw(1);
+
+        vm.expectRevert(Orb.NotPermittedForLeadingBidder.selector);
+        vm.prank(user);
+        orb.withdrawAll();
+
+        // user is no longer the leadingBidder
+        prankAndBid(user2, 2 ether);
+
+        // user can withdraw
+        uint256 fundsBefore = orb.fundsOf(user);
+        vm.startPrank(user);
+        assertEq(user.balance, startingBalance);
+        orb.withdraw(100);
+        assertEq(user.balance, startingBalance + 100);
+        assertEq(orb.fundsOf(user), fundsBefore - 100);
+        orb.withdrawAll();
+        assertEq(orb.fundsOf(user), 0);
+        assertEq(user.balance, startingBalance + fundsBefore);
+    }
+
+    event Settlement(address indexed keeper, address indexed beneficiary, uint256 indexed amount);
+
+    function test_withdrawSettlesFirstIfKeeper() public {
+        assertEq(orb.fundsOf(user), 0);
+        // winning bid  = 1 ether
+        uint256 bidAmount = 10 ether;
+        uint256 smallBidAmount = 0.5 ether;
+        uint256 withdrawAmount = 0.1 ether;
+
+        orb.startAuction();
+        // user2 bids
+        prankAndBid(user2, smallBidAmount);
+        // user1 bids and becomes the leading bidder
+        prankAndBid(user, bidAmount);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+
+        vm.warp(block.timestamp + 30 days);
+
+        // beneficiaryEffective = beneficiaryFunds + transferableToBeneficiary
+        // userEffective = userFunds - transferableToBeneficiary
+        uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
+        uint256 userEffective = effectiveFundsOf(user);
+        uint256 beneficiaryEffective = effectiveFundsOf(beneficiary);
+        uint256 transferableToBeneficiary = beneficiaryEffective - beneficiaryFunds;
+        uint256 initialBalance = user.balance;
+
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, transferableToBeneficiary);
+
+        vm.prank(user);
+        orb.withdraw(withdrawAmount);
+
+        assertEq(orb.fundsOf(user), userEffective - withdrawAmount);
+        assertEq(orb.fundsOf(beneficiary), beneficiaryEffective);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(user.balance, initialBalance + withdrawAmount);
+
+        // move ahead 10 days;
+        vm.warp(block.timestamp + 10 days);
+
+        // not keeper
+        vm.prank(user2);
+        initialBalance = user2.balance;
+        orb.withdraw(withdrawAmount);
+        assertEq(orb.fundsOf(user2), fundsRequiredToBidOneYear(smallBidAmount) - withdrawAmount);
+        assertEq(user2.balance, initialBalance + withdrawAmount);
+    }
+
+    function test_withdrawAllForBeneficiarySettlesAndWithdraws() public {
+        assertEq(orb.fundsOf(user), 0);
+        // winning bid  = 1 ether
+        uint256 bidAmount = 10 ether;
+        uint256 smallBidAmount = 0.5 ether;
+
+        orb.startAuction();
+        // user2 bids
+        prankAndBid(user2, smallBidAmount);
+        // user1 bids and becomes the leading bidder
+        prankAndBid(user, bidAmount);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+
+        vm.warp(block.timestamp + 30 days);
+
+        // beneficiaryEffective = beneficiaryFunds + transferableToBeneficiary
+        // userEffective = userFunds - transferableToBeneficiary
+        uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
+        uint256 userEffective = effectiveFundsOf(user);
+        uint256 beneficiaryEffective = effectiveFundsOf(beneficiary);
+        uint256 transferableToBeneficiary = beneficiaryEffective - beneficiaryFunds;
+        uint256 initialBalance = beneficiary.balance;
+
+        vm.prank(user);
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, transferableToBeneficiary);
+
+        vm.expectEmit(true, true, true, true);
+        emit Withdrawal(beneficiary, beneficiaryFunds + transferableToBeneficiary);
+        orb.withdrawAllForBeneficiary();
+
+        assertEq(orb.fundsOf(user), userEffective);
+        assertEq(orb.fundsOf(beneficiary), 0);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(beneficiary.balance, initialBalance + beneficiaryEffective);
+    }
+
+    function test_withdrawAllForBeneficiaryWhenContractOwned() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(user);
+        orb.relinquish(false);
+
+        uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
+        uint256 initialBalance = beneficiary.balance;
+        uint256 settlementTime = block.timestamp;
+
+        vm.warp(block.timestamp + 30 days);
+
+        // expectNotEmit Settlement
+        vm.expectEmit(true, true, true, true);
+        emit Withdrawal(beneficiary, beneficiaryFunds);
+        orb.withdrawAllForBeneficiary();
+
+        assertEq(orb.fundsOf(beneficiary), 0);
+        assertEq(orb.lastSettlementTime(), settlementTime);
+        assertEq(beneficiary.balance, initialBalance + beneficiaryFunds);
+    }
+
+    function test_withdrawAllForBeneficiaryWhenCreatorOwned() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(user);
+        orb.relinquish(false);
+        vm.prank(owner);
+        orb.listWithPrice(1 ether);
+
+        uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
+        uint256 initialBalance = beneficiary.balance;
+
+        vm.warp(block.timestamp + 30 days);
+
+        vm.expectEmit(true, true, true, true);
+        emit Withdrawal(beneficiary, beneficiaryFunds);
+        orb.withdrawAllForBeneficiary();
+
+        assertEq(orb.fundsOf(beneficiary), 0);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(beneficiary.balance, initialBalance + beneficiaryFunds);
+    }
+
+    function testFuzz_withdrawSettlesFirstIfKeeper(uint256 bidAmount, uint256 withdrawAmount) public {
+        assertEq(orb.fundsOf(user), 0);
+        // winning bid  = 1 ether
+        bidAmount = bound(bidAmount, orb.auctionStartingPrice(), orb.workaround_maximumPrice());
+        makeKeeperAndWarp(user, bidAmount);
+
+        // beneficiaryEffective = beneficiaryFunds + transferableToBeneficiary
+        // userEffective = userFunds - transferableToBeneficiary
+        uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
+        uint256 userEffective = effectiveFundsOf(user);
+        uint256 beneficiaryEffective = effectiveFundsOf(beneficiary);
+        uint256 transferableToBeneficiary = beneficiaryEffective - beneficiaryFunds;
+        uint256 initialBalance = user.balance;
+
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, transferableToBeneficiary);
+
+        vm.prank(user);
+        withdrawAmount = bound(withdrawAmount, 0, userEffective - 1);
+        orb.withdraw(withdrawAmount);
+        assertEq(orb.fundsOf(user), userEffective - withdrawAmount);
+        assertEq(orb.fundsOf(beneficiary), beneficiaryEffective);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(user.balance, initialBalance + withdrawAmount);
+
+        vm.prank(user);
+        orb.withdrawAll();
+        assertEq(orb.fundsOf(user), 0);
+        assertEq(orb.fundsOf(beneficiary), beneficiaryEffective);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(user.balance, initialBalance + userEffective);
+    }
+
+    function test_withdrawRevertsIfInsufficientFunds() public {
+        vm.startPrank(user);
+        orb.deposit{value: 1 ether}();
+        assertEq(orb.fundsOf(user), 1 ether);
+        vm.expectRevert(abi.encodeWithSelector(Orb.InsufficientFunds.selector, 1 ether, 1 ether + 1));
+        orb.withdraw(1 ether + 1);
+        assertEq(orb.fundsOf(user), 1 ether);
+        vm.expectEmit(true, true, true, true);
+        emit Withdrawal(user, 1 ether);
+        orb.withdraw(1 ether);
+        assertEq(orb.fundsOf(user), 0);
+    }
+}
+
+contract SettleTest is OrbTestBase {
+    event Settlement(address indexed keeper, address indexed beneficiary, uint256 indexed amount);
+
+    function test_settleOnlyIfKeeperHeld() public {
+        vm.expectRevert(Orb.ContractHoldsOrb.selector);
+        orb.settle();
+        assertEq(orb.lastSettlementTime(), 0);
+        makeKeeperAndWarp(user, 1 ether);
+        orb.settle();
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+    }
+
+    function testFuzz_settleCorrect(uint96 bid, uint96 time) public {
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 100_000_000);
+        uint256 amount = bound(bid, orb.auctionStartingPrice(), orb.workaround_maximumPrice());
+        // warp ahead a random amount of time
+        // remain under 1 year in total, so solvent
+        uint256 timeOffset = bound(time, 0, 300 days);
+        vm.warp(block.timestamp + timeOffset);
+        assertEq(orb.fundsOf(user), 0);
+        assertEq(orb.fundsOf(beneficiary), 0);
+        assertEq(orb.lastSettlementTime(), 0);
+        // it warps 30 days by default
+        makeKeeperAndWarp(user, amount);
+
+        uint256 userEffective = effectiveFundsOf(user);
+        uint256 beneficiaryEffective = effectiveFundsOf(beneficiary);
+        uint256 initialBalance = user.balance;
+
+        orb.settle();
+        assertEq(orb.fundsOf(user), userEffective);
+        assertEq(orb.fundsOf(beneficiary), beneficiaryEffective);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(user.balance, initialBalance);
+
+        timeOffset = bound(time, block.timestamp + 340 days, type(uint96).max);
+        vm.warp(timeOffset);
+
+        // user is no longer solvent
+        // the user can't pay the full owed feeds, so they
+        // pay what they can
+        uint256 transferable = orb.fundsOf(user);
+        orb.settle();
+        assertEq(orb.fundsOf(user), 0);
+        // beneficiaryEffective is from the last time it settled
+        assertEq(orb.fundsOf(beneficiary), transferable + beneficiaryEffective);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(user.balance, initialBalance);
+    }
+
+    function test_settleReturnsIfOwner() public {
+        orb.listWithPrice(1 ether);
+        vm.warp(30 days);
+        uint256 beneficiaryFunds = orb.fundsOf(beneficiary);
+        orb.workaround_settle();
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+        assertEq(orb.fundsOf(beneficiary), beneficiaryFunds);
+    }
+}
+
+contract KeeperSolventTest is OrbTestBase {
+    function test_keeperSolventCorrectIfNotOwner() public {
+        assertEq(orb.fundsOf(user), 0);
+        assertEq(orb.fundsOf(owner), 0);
+        assertEq(orb.lastSettlementTime(), 0);
+        // it warps 30 days by default
+        makeKeeperAndWarp(user, 1 ether);
+        assert(orb.keeperSolvent());
+        vm.warp(block.timestamp + 700 days);
+        assertFalse(orb.keeperSolvent());
+    }
+
+    function test_keeperSolventCorrectIfOwner() public {
+        assertEq(orb.fundsOf(user), 0);
+        assertEq(orb.fundsOf(owner), 0);
+        assertEq(orb.lastSettlementTime(), 0);
+        assert(orb.keeperSolvent());
+        vm.warp(block.timestamp + 4885828483 days);
+        assert(orb.keeperSolvent());
+    }
+}
+
+contract OwedSinceLastSettlementTest is OrbTestBase {
+    function test_owedSinceLastSettlementCorrectMath() public {
+        // _lastSettlementTime = 0
+        // secondsSinceLastSettlement = block.timestamp - _lastSettlementTime
+        // KEEPER_TAX_NUMERATOR = 10_00
+        // feeDenominator = 100_00
+        // keeperTaxPeriod  = 365 days = 31_536_000 seconds
+        // owed = _price * KEEPER_TAX_NUMERATOR * secondsSinceLastSettlement)
+        // / (keeperTaxPeriod * feeDenominator);
+        // Scenario:
+        // _price = 17 ether = 17_000_000_000_000_000_000 wei
+        // block.timestamp = 167710711
+        // owed = 90.407.219.961.314.053.779,8072044647
+        vm.prank(owner);
+        orb.setFees(10_00, 0, 0);
+        orb.workaround_setPrice(17 ether);
+        vm.warp(167710711);
+        // calculation done off-solidity to verify precision with another environment
+        assertEq(orb.workaround_owedSinceLastSettlement(), 9_040_721_990_740_740_740);
+        // 108488663888888888888
+    }
+}

--- a/test/OrbV3/OrbV3-Purchase.t.sol
+++ b/test/OrbV3/OrbV3-Purchase.t.sol
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {Test} from "../../lib/forge-std/src/Test.sol";
+
+import {OrbTestBase} from "./OrbV3.t.sol";
+import {Orb} from "../../src/Orb.sol";
+import {OrbV3} from "../../src/OrbV3.sol";
+
+/* solhint-disable func-name-mixedcase */
+contract SetPriceTest is OrbTestBase {
+    function test_setPriceRevertsIfNotKeeper() public {
+        uint256 leadingBid = 10 ether;
+        makeKeeperAndWarp(user, leadingBid);
+        vm.expectRevert(Orb.NotKeeper.selector);
+        vm.prank(user2);
+        orb.setPrice(1 ether);
+        assertEq(orb.price(), 10 ether);
+
+        vm.prank(user);
+        orb.setPrice(1 ether);
+        assertEq(orb.price(), 1 ether);
+    }
+
+    function test_setPriceRevertsIfKeeperInsolvent() public {
+        uint256 leadingBid = 10 ether;
+        makeKeeperAndWarp(user, leadingBid);
+        vm.warp(block.timestamp + 600 days);
+        vm.startPrank(user);
+        vm.expectRevert(Orb.KeeperInsolvent.selector);
+        orb.setPrice(1 ether);
+
+        // As the user can't deposit funds to become solvent again
+        // we modify a variable to trick the contract
+        orb.workaround_setLastSettlementTime(block.timestamp);
+        orb.setPrice(2 ether);
+        assertEq(orb.price(), 2 ether);
+    }
+
+    function test_setPriceSettlesBefore() public {
+        uint256 leadingBid = 10 ether;
+        makeKeeperAndWarp(user, leadingBid);
+        vm.prank(user);
+        orb.setPrice(2 ether);
+        assertEq(orb.price(), 2 ether);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+    }
+
+    event PriceUpdate(uint256 previousPrice, uint256 indexed newPrice);
+
+    function test_setPriceRevertsIfMaxPrice() public {
+        uint256 maxPrice = orb.workaround_maximumPrice();
+        uint256 leadingBid = 10 ether;
+        makeKeeperAndWarp(user, leadingBid);
+        vm.startPrank(user);
+        vm.expectRevert(abi.encodeWithSelector(Orb.InvalidNewPrice.selector, maxPrice + 1));
+        orb.setPrice(maxPrice + 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit PriceUpdate(10 ether, maxPrice);
+        orb.setPrice(maxPrice);
+    }
+
+    function test_setPriceRevertsIfPriceTooLow() public {
+        orb.setMinimumPrice(1 ether);
+        uint256 minPrice = orb.minimumPrice();
+        makeKeeperAndWarp(user, 1 ether);
+        vm.startPrank(user);
+        vm.expectRevert(abi.encodeWithSelector(OrbV3.PriceTooLow.selector, minPrice - 1, orb.minimumPrice()));
+        orb.setPrice(minPrice - 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit PriceUpdate(1 ether, minPrice);
+        orb.setPrice(minPrice);
+    }
+}
+
+contract PurchaseTest is OrbTestBase {
+    function test_revertsIfHeldByContract() public {
+        vm.prank(user);
+        vm.expectRevert(Orb.ContractHoldsOrb.selector);
+        orb.purchase(100, 0, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+    }
+
+    function test_revertsIfKeeperInsolvent() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.warp(block.timestamp + 1300 days);
+        vm.prank(user2);
+        vm.expectRevert(Orb.KeeperInsolvent.selector);
+        orb.purchase(100, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+    }
+
+    function test_purchaseSettlesFirst() public {
+        makeKeeperAndWarp(user, 1 ether);
+        // after making `user` the current keeper of the Orb, `makeKeeperAndWarp(user, )` warps 30 days into the future
+        assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
+        vm.prank(user2);
+        orb.purchase{value: 1.1 ether}(2 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+    }
+
+    function test_revertsIfBeneficiary() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.deal(beneficiary, 1.1 ether);
+        vm.prank(beneficiary);
+        vm.expectRevert(abi.encodeWithSelector(Orb.NotPermitted.selector));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+
+        // does not revert
+        assertEq(orb.lastSettlementTime(), block.timestamp - 30 days);
+        vm.prank(user2);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+        assertEq(orb.lastSettlementTime(), block.timestamp);
+    }
+
+    function test_revertsIfWrongCurrentPrice() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(user2);
+        vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 2 ether, 1 ether));
+        orb.purchase{value: 1.1 ether}(3 ether, 2 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+    }
+
+    function test_revertsIfWrongCurrentValues() public {
+        orb.listWithPrice(1 ether);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 200_00, 120_00));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 200_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 30_00, 10_00));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 30_00, 30_00, 7 days, 300, 20_000_000);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 10_00, 30_00));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 10_00, 7 days, 300, 20_000_000);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 8 days, 7 days));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 8 days, 300, 20_000_000);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 150, 300));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 150, 20_000_000);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Orb.CurrentValueIncorrect.selector, 10_000_000, 20_000_000));
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 10_000_000);
+
+        vm.prank(user);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+    }
+
+    function test_revertsIfIfAlreadyKeeper() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.expectRevert(Orb.AlreadyKeeper.selector);
+        vm.prank(user);
+        orb.purchase{value: 1.1 ether}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+    }
+
+    function test_revertsIfInsufficientFunds() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.expectRevert(abi.encodeWithSelector(Orb.InsufficientFunds.selector, 1 ether - 1, 1 ether));
+        vm.prank(user2);
+        orb.purchase{value: 1 ether - 1}(3 ether, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+    }
+
+    function test_revertsIfPurchasingAfterSetPrice() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(user);
+        orb.setPrice(0);
+        vm.expectRevert(abi.encodeWithSelector(Orb.PurchasingNotPermitted.selector));
+        vm.prank(user2);
+        orb.purchase(1 ether, 0, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+    }
+
+    function test_revertsIfPriceTooHigh() public {
+        makeKeeperAndWarp(user, 1 ether);
+        uint256 price = orb.workaround_maximumPrice() + 1;
+        vm.deal(user2, price);
+        vm.prank(user2);
+        vm.expectRevert(abi.encodeWithSelector(Orb.InvalidNewPrice.selector, price));
+        orb.purchase{value: price}(price, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+
+        vm.expectEmit(true, true, true, true);
+        emit Purchase(user, user2, 1 ether);
+        vm.prank(user2);
+        orb.purchase{value: price}(price - 1, 1 ether, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+
+        assertEq(orb.price(), orb.workaround_maximumPrice());
+    }
+
+    function test_revertsIfPriceTooLow() public {
+        uint256 minimumPrice = 1 ether;
+        orb.setMinimumPrice(minimumPrice);
+
+        makeKeeperAndWarp(user, minimumPrice);
+        uint256 price = minimumPrice - 1;
+
+        vm.prank(user2);
+        vm.expectRevert(abi.encodeWithSelector(OrbV3.PriceTooLow.selector, price, minimumPrice));
+        orb.purchase{value: minimumPrice}(price, minimumPrice, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+
+        vm.expectEmit(true, true, true, true);
+        emit Purchase(user, user2, minimumPrice);
+        vm.prank(user2);
+        orb.purchase{value: minimumPrice}(price + 1, minimumPrice, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+
+        assertEq(orb.price(), orb.minimumPrice());
+    }
+
+    event Purchase(address indexed seller, address indexed buyer, uint256 indexed price);
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event PriceUpdate(uint256 previousPrice, uint256 indexed newPrice);
+    event Settlement(address indexed keeper, address indexed beneficiary, uint256 indexed amount);
+
+    function test_beneficiaryAllProceedsIfOwnerSells() public {
+        uint256 bidAmount = 1 ether;
+        uint256 newPrice = 3 ether;
+        uint256 purchaseAmount = bidAmount / 2;
+        uint256 depositAmount = bidAmount / 2;
+        // bidAmount will be the `_price` of the Orb
+        makeKeeperAndWarp(owner, bidAmount);
+        orb.settle();
+        vm.warp(block.timestamp + 1 days);
+        uint256 ownerBefore = orb.fundsOf(owner);
+        uint256 beneficiaryBefore = orb.fundsOf(beneficiary);
+        uint256 userBefore = orb.fundsOf(user);
+        vm.startPrank(user);
+        orb.deposit{value: depositAmount}();
+        assertEq(orb.fundsOf(user), userBefore + depositAmount);
+        vm.expectEmit(true, true, true, true);
+        emit Purchase(owner, user, bidAmount);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(owner, user, 1);
+        // The Orb is purchased with purchaseAmount
+        // It uses both the existing funds of the user and the funds
+        // that the user transfers when calling `purchase()`
+        orb.purchase{value: purchaseAmount + 1}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+        uint256 beneficiaryRoyalty = bidAmount;
+        assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty);
+        assertEq(orb.fundsOf(owner), ownerBefore);
+        // The price of the Orb was 1 ether and user2 transfered 1 ether + 1 to buy it
+        assertEq(orb.fundsOf(user), 1);
+        assertEq(orb.price(), newPrice);
+        assertEq(orb.lastInvocationTime(), block.timestamp - orb.cooldown());
+        assertEq(orb.keeperSolvent(), true);
+    }
+
+    function test_succeedsCorrectly() public {
+        uint256 bidAmount = 1 ether;
+        uint256 newPrice = 3 ether;
+        uint256 expectedSettlement = bidAmount * orb.keeperTaxNumerator() / orb.feeDenominator();
+        uint256 purchaseAmount = bidAmount / 2;
+        uint256 depositAmount = bidAmount / 2;
+        // bidAmount will be the `_price` of the Orb
+        makeKeeperAndWarp(user, bidAmount);
+        orb.settle();
+        vm.prank(user);
+        orb.deposit{value: expectedSettlement}();
+        uint256 ownerBefore = orb.fundsOf(owner);
+        uint256 beneficiaryBefore = orb.fundsOf(beneficiary);
+        uint256 userBefore = orb.fundsOf(user);
+        uint256 lastInvocationTimeBefore = orb.lastInvocationTime();
+        vm.warp(block.timestamp + 365 days);
+        vm.prank(user2);
+        orb.deposit{value: depositAmount}();
+        assertEq(orb.fundsOf(user2), depositAmount);
+        vm.expectEmit(true, true, true, true);
+        // 1 year has passed since the last settlement
+        emit Settlement(user, beneficiary, expectedSettlement);
+        vm.expectEmit(true, true, true, true);
+        emit PriceUpdate(bidAmount, newPrice);
+        vm.expectEmit(true, true, true, true);
+        emit Purchase(user, user2, bidAmount);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(user, user2, 1);
+        // The Orb is purchased with purchaseAmount
+        // It uses both the existing funds of the user and the funds
+        // that the user transfers when calling `purchase()`
+        vm.prank(user2);
+        orb.purchase{value: purchaseAmount + 1}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+        uint256 beneficiaryRoyalty = ((bidAmount * orb.purchaseRoyaltyNumerator()) / orb.feeDenominator());
+        assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty + expectedSettlement);
+        assertEq(orb.fundsOf(user), userBefore + bidAmount - (beneficiaryRoyalty + expectedSettlement));
+        assertEq(orb.fundsOf(owner), ownerBefore);
+        // The price of the Orb was 1 ether and user2 transfered 1 ether + 1 to buy it
+        assertEq(orb.fundsOf(user2), 1);
+        assertEq(orb.price(), newPrice);
+        assertEq(orb.lastInvocationTime(), lastInvocationTimeBefore);
+    }
+
+    function testFuzz_succeedsCorrectly(uint256 bidAmount, uint256 newPrice, uint256 buyPrice, uint256 diff) public {
+        bidAmount = bound(bidAmount, 0.1 ether, orb.workaround_maximumPrice() - 1);
+        newPrice = bound(newPrice, 1, orb.workaround_maximumPrice());
+        buyPrice = bound(buyPrice, bidAmount + 1, orb.workaround_maximumPrice());
+        diff = bound(diff, 1, buyPrice);
+        uint256 expectedSettlement = bidAmount * orb.keeperTaxNumerator() / orb.feeDenominator();
+        vm.deal(user2, buyPrice);
+        /// Break up the amount between depositing and purchasing to test more scenarios
+        uint256 purchaseAmount = buyPrice - diff;
+        uint256 depositAmount = diff;
+        // bidAmount will be the `_price` of the Orb
+        makeKeeperAndWarp(user, bidAmount);
+        vm.deal(user, bidAmount + expectedSettlement);
+        orb.settle();
+        vm.startPrank(user);
+        orb.deposit{value: expectedSettlement}();
+        uint256 ownerBefore = orb.fundsOf(owner);
+        uint256 beneficiaryBefore = orb.fundsOf(beneficiary);
+        uint256 userBefore = orb.fundsOf(user);
+        vm.stopPrank();
+        vm.warp(block.timestamp + 365 days);
+        vm.prank(user2);
+        orb.deposit{value: depositAmount}();
+        assertEq(orb.fundsOf(user2), depositAmount);
+        vm.expectEmit(true, true, true, true);
+        // 1 year has passed since the last settlement
+        emit Settlement(user, beneficiary, expectedSettlement);
+        vm.expectEmit(true, true, true, true);
+        emit PriceUpdate(bidAmount, newPrice);
+        vm.expectEmit(true, true, true, true);
+        emit Purchase(user, user2, bidAmount);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(user, user2, 1);
+        // The Orb is purchased with purchaseAmount
+        // It uses both the existing funds of the user and the funds
+        // that the user transfers when calling `purchase()`
+        // We bound the purchaseAmount to be higher than the current price (bidAmount)
+        vm.prank(user2);
+        orb.purchase{value: purchaseAmount}(newPrice, bidAmount, 120_00, 10_00, 30_00, 7 days, 300, 20_000_000);
+        uint256 beneficiaryRoyalty = ((bidAmount * orb.purchaseRoyaltyNumerator()) / orb.feeDenominator());
+        assertEq(orb.fundsOf(beneficiary), beneficiaryBefore + beneficiaryRoyalty + expectedSettlement);
+        assertEq(orb.fundsOf(user), userBefore + bidAmount - (beneficiaryRoyalty + expectedSettlement));
+        assertEq(orb.fundsOf(owner), ownerBefore);
+        // User2 transfered buyPrice to the contract
+        // User2 paid bidAmount
+        assertEq(orb.fundsOf(user2), buyPrice - bidAmount);
+        assertEq(orb.price(), newPrice);
+    }
+
+    function test_previousFunctionSignatureNotSupported() public {
+        orb.listWithPrice(1 ether);
+
+        vm.prank(user);
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.purchase{value: 1 ether}(2 ether, 1 ether, 120_00, 10_00, 7 days, 300);
+    }
+}

--- a/test/OrbV3/OrbV3-Settings.t.sol
+++ b/test/OrbV3/OrbV3-Settings.t.sol
@@ -1,0 +1,731 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {Test} from "../../lib/forge-std/src/Test.sol";
+import {ClonesUpgradeable} from "../../lib/openzeppelin-contracts-upgradeable/contracts/proxy/ClonesUpgradeable.sol";
+
+import {OrbTestBase} from "./OrbV3.t.sol";
+import {Orb} from "../../src/Orb.sol";
+import {OrbV2} from "../../src/OrbV2.sol";
+import {OrbV3} from "../../src/OrbV3.sol";
+import {PaymentSplitter} from "../../src/CustomPaymentSplitter.sol";
+
+/* solhint-disable func-name-mixedcase */
+contract SwearOathTest is OrbTestBase {
+    event OathSwearing(bytes32 indexed oathHash, uint256 indexed honoredUntil);
+
+    function test_swearOathOnlyOwnerControlled() public {
+        vm.prank(user);
+        vm.expectRevert("Ownable: caller is not the owner");
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 10_000_000);
+
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        vm.expectRevert(Orb.AuctionRunning.selector);
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 10_000_000);
+
+        prankAndBid(user, 1 ether);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+
+        vm.prank(owner);
+        vm.expectRevert(Orb.CreatorDoesNotControlOrb.selector);
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 10_000_000);
+    }
+
+    function test_swearOathCorrectly() public {
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        // keccak hash of "test oath"
+        emit OathSwearing(0xa0a79538f3c69ab225db00333ba71e9265d3835a715fd7e15ada45dc746608bc, 10_000_000);
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 10_000_000);
+        assertEq(orb.honoredUntil(), 10_000_000);
+    }
+
+    function test_swearOathWhileOwnerHeld() public {
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 10_000_000);
+        orb.listWithPrice(1 ether);
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit OathSwearing(0xa0a79538f3c69ab225db00333ba71e9265d3835a715fd7e15ada45dc746608bc, 5_000_000);
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 5_000_000);
+        assertEq(orb.honoredUntil(), 5_000_000);
+    }
+
+    function test_reswearIfPreviousOathExpired() public {
+        makeKeeperAndWarp(user, 1 ether);
+
+        assertGt(orb.honoredUntil(), block.timestamp);
+        vm.prank(owner);
+        vm.expectRevert(Orb.CreatorDoesNotControlOrb.selector);
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 30_000_000);
+
+        vm.warp(orb.honoredUntil() + 1);
+        assertLt(orb.honoredUntil(), block.timestamp);
+
+        vm.prank(owner);
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 30_000_000);
+        assertGt(orb.honoredUntil(), block.timestamp);
+    }
+
+    function test_previousFunctionSignatureNotSupported() public {
+        vm.prank(owner);
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 20_000_000, 3600);
+    }
+}
+
+contract ExtendHonoredUntilTest is OrbTestBase {
+    event HonoredUntilUpdate(uint256 previousHonoredUntil, uint256 indexed newHonoredUntil);
+
+    function test_extendHonoredUntilOnlyOwner() public {
+        vm.prank(user);
+        vm.expectRevert("Ownable: caller is not the owner");
+        orb.extendHonoredUntil(20_000_001);
+
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(owner);
+        orb.extendHonoredUntil(20_000_001);
+    }
+
+    function test_extendHonoredUntilNotDecrease() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(owner);
+        vm.expectRevert(Orb.HonoredUntilNotDecreasable.selector);
+        orb.extendHonoredUntil(99);
+    }
+
+    function test_extendHonoredUntilCorrectly() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit HonoredUntilUpdate(20_000_000, 20_000_001);
+        orb.extendHonoredUntil(20_000_001);
+    }
+}
+
+contract SettingTokenURITest is OrbTestBase {
+    function test_tokenURIrevertsIfUser() public {
+        vm.prank(user);
+        vm.expectRevert("Ownable: caller is not the owner");
+        orb.setTokenURI("https://static.orb.land/new/");
+    }
+
+    function test_tokenURISetsCorrectState() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(owner);
+        orb.setTokenURI("https://static.orb.land/new/");
+        assertEq(orb.workaround_tokenURI(), "https://static.orb.land/new/");
+    }
+}
+
+contract SettingAuctionParametersTest is OrbTestBase {
+    event AuctionParametersUpdate(
+        uint256 previousStartingPrice,
+        uint256 indexed newStartingPrice,
+        uint256 previousMinimumBidStep,
+        uint256 indexed newMinimumBidStep,
+        uint256 previousMinimumDuration,
+        uint256 indexed newMinimumDuration,
+        uint256 previousKeeperMinimumDuration,
+        uint256 newKeeperMinimumDuration,
+        uint256 previousBidExtension,
+        uint256 newBidExtension
+    );
+
+    function test_setAuctionParametersOnlyOwnerControlled() public {
+        vm.prank(user);
+        vm.expectRevert("Ownable: caller is not the owner");
+        orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 1 days, 10 minutes);
+
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        vm.expectRevert(Orb.AuctionRunning.selector);
+        orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 1 days, 10 minutes);
+
+        prankAndBid(user, 1 ether);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+
+        vm.prank(owner);
+        vm.expectRevert(Orb.CreatorDoesNotControlOrb.selector);
+        orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 1 days, 10 minutes);
+    }
+
+    function test_revertIfAuctionDurationZero() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(Orb.InvalidAuctionDuration.selector, 0));
+        orb.setAuctionParameters(0.2 ether, 0.2 ether, 0, 1 days, 10 minutes);
+    }
+
+    function test_allowKeeperAuctionDurationZero() public {
+        vm.prank(owner);
+        orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 0, 10 minutes);
+    }
+
+    function test_boundMinBidStepToAbove0() public {
+        assertEq(orb.auctionStartingPrice(), 0.1 ether);
+        assertEq(orb.auctionMinimumBidStep(), 0.1 ether);
+        vm.prank(owner);
+        orb.setAuctionParameters(0, 0, 1 days, 1 days, 10 minutes);
+        assertEq(orb.auctionStartingPrice(), 0);
+        assertEq(orb.auctionMinimumBidStep(), 1);
+
+        vm.prank(owner);
+        orb.setAuctionParameters(0, 2, 1 days, 1 days, 10 minutes);
+        assertEq(orb.auctionStartingPrice(), 0);
+        assertEq(orb.auctionMinimumBidStep(), 2);
+    }
+
+    function test_setAuctionParametersSucceedsCorrectly() public {
+        assertEq(orb.auctionStartingPrice(), 0.1 ether);
+        assertEq(orb.auctionMinimumBidStep(), 0.1 ether);
+        assertEq(orb.auctionMinimumDuration(), 1 days);
+        assertEq(orb.auctionKeeperMinimumDuration(), 6 hours);
+        assertEq(orb.auctionBidExtension(), 5 minutes);
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit AuctionParametersUpdate(
+            0.1 ether, 0.2 ether, 0.1 ether, 0.2 ether, 1 days, 2 days, 6 hours, 1 days, 5 minutes, 10 minutes
+        );
+        orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 1 days, 10 minutes);
+        assertEq(orb.auctionStartingPrice(), 0.2 ether);
+        assertEq(orb.auctionMinimumBidStep(), 0.2 ether);
+        assertEq(orb.auctionMinimumDuration(), 2 days);
+        assertEq(orb.auctionKeeperMinimumDuration(), 1 days);
+        assertEq(orb.auctionBidExtension(), 10 minutes);
+    }
+
+    function test_succeedsIfOathExpired() public {
+        makeKeeperAndWarp(user, 1 ether);
+
+        assertGt(orb.honoredUntil(), block.timestamp);
+        vm.prank(owner);
+        vm.expectRevert(Orb.CreatorDoesNotControlOrb.selector);
+        orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 1 days, 10 minutes);
+
+        assertTrue(orb.auctionStartingPrice() != 0.2 ether);
+        assertTrue(orb.auctionMinimumBidStep() != 0.2 ether);
+        assertTrue(orb.auctionMinimumDuration() != 2 days);
+        assertTrue(orb.auctionKeeperMinimumDuration() != 1 days);
+        assertTrue(orb.auctionBidExtension() != 10 minutes);
+
+        vm.warp(orb.honoredUntil() + 1);
+        assertLt(orb.honoredUntil(), block.timestamp);
+
+        vm.prank(owner);
+        orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 1 days, 10 minutes);
+        assertEq(orb.auctionStartingPrice(), 0.2 ether);
+        assertEq(orb.auctionMinimumBidStep(), 0.2 ether);
+        assertEq(orb.auctionMinimumDuration(), 2 days);
+        assertEq(orb.auctionKeeperMinimumDuration(), 1 days);
+        assertEq(orb.auctionBidExtension(), 10 minutes);
+    }
+
+    function test_setAuctionParametersWhileOwnerHeld() public {
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 20_000_000);
+        orb.listWithPrice(1 ether);
+
+        assertTrue(orb.auctionStartingPrice() != 0.2 ether);
+        assertTrue(orb.auctionMinimumBidStep() != 0.2 ether);
+        assertTrue(orb.auctionMinimumDuration() != 2 days);
+        assertTrue(orb.auctionKeeperMinimumDuration() != 1 days);
+        assertTrue(orb.auctionBidExtension() != 10 minutes);
+        assertGt(orb.honoredUntil(), block.timestamp);
+
+        vm.prank(owner);
+        orb.setAuctionParameters(0.2 ether, 0.2 ether, 2 days, 1 days, 10 minutes);
+        assertEq(orb.auctionStartingPrice(), 0.2 ether);
+        assertEq(orb.auctionMinimumBidStep(), 0.2 ether);
+        assertEq(orb.auctionMinimumDuration(), 2 days);
+        assertEq(orb.auctionKeeperMinimumDuration(), 1 days);
+        assertEq(orb.auctionBidExtension(), 10 minutes);
+    }
+}
+
+contract SettingFeesTest is OrbTestBase {
+    event FeesUpdate(
+        uint256 previousKeeperTaxNumerator,
+        uint256 indexed newKeeperTaxNumerator,
+        uint256 previousPurchaseRoyaltyNumerator,
+        uint256 indexed newPurchaseRoyaltyNumerator,
+        uint256 previousAuctionRoyaltyNumerator,
+        uint256 indexed newAuctionRoyaltyNumerator
+    );
+
+    function test_setFeesOnlyOwnerControlled() public {
+        vm.prank(user);
+        vm.expectRevert("Ownable: caller is not the owner");
+        orb.setFees(100_00, 100_00, 100_00);
+
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        vm.expectRevert(Orb.AuctionRunning.selector);
+        orb.setFees(100_00, 100_00, 100_00);
+
+        prankAndBid(user, 1 ether);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+
+        vm.prank(owner);
+        vm.expectRevert(Orb.CreatorDoesNotControlOrb.selector);
+        orb.setFees(100_00, 100_00, 100_00);
+    }
+
+    function test_revertIfRoyaltyNumeratorExceedsDenominator() public {
+        uint256 largeNumerator = orb.feeDenominator() + 1;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Orb.RoyaltyNumeratorExceedsDenominator.selector, largeNumerator, orb.feeDenominator()
+            )
+        );
+        vm.prank(owner);
+        orb.setFees(largeNumerator, largeNumerator - 1, largeNumerator);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Orb.RoyaltyNumeratorExceedsDenominator.selector, largeNumerator, orb.feeDenominator()
+            )
+        );
+        vm.prank(owner);
+        orb.setFees(largeNumerator, largeNumerator, largeNumerator - 1);
+
+        vm.prank(owner);
+        orb.setFees(largeNumerator, orb.feeDenominator(), orb.feeDenominator());
+
+        assertEq(orb.keeperTaxNumerator(), largeNumerator);
+        assertEq(orb.purchaseRoyaltyNumerator(), orb.feeDenominator());
+        assertEq(orb.auctionRoyaltyNumerator(), orb.feeDenominator());
+    }
+
+    function test_setFeesSucceedsCorrectly() public {
+        assertEq(orb.keeperTaxNumerator(), 120_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 10_00);
+        assertEq(orb.auctionRoyaltyNumerator(), 30_00);
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit FeesUpdate(120_00, 100_00, 10_00, 100_00, 30_00, 100_00);
+
+        orb.setFees(100_00, 100_00, 100_00);
+        assertEq(orb.keeperTaxNumerator(), 100_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 100_00);
+        assertEq(orb.auctionRoyaltyNumerator(), 100_00);
+    }
+
+    event Settlement(address indexed keeper, address indexed beneficiary, uint256 indexed amount);
+
+    function test_succeedsIfOathExpired() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(user);
+        orb.deposit{value: 1000 ether}();
+        uint256 expectedSettlementTime = block.timestamp - 30 days;
+        assertGt(orb.workaround_owedSinceLastSettlement(), 0);
+        assertEq(orb.lastSettlementTime(), expectedSettlementTime);
+
+        assertGt(orb.honoredUntil(), block.timestamp);
+        vm.prank(owner);
+        vm.expectRevert(Orb.CreatorDoesNotControlOrb.selector);
+        orb.setFees(200_00, 90_00, 90_00);
+
+        assertTrue(orb.keeperTaxNumerator() != 200_00);
+        assertTrue(orb.purchaseRoyaltyNumerator() != 90_00);
+        assertTrue(orb.auctionRoyaltyNumerator() != 90_00);
+
+        vm.warp(orb.honoredUntil() + 1);
+        assertLt(orb.honoredUntil(), block.timestamp);
+        assertGt(orb.workaround_owedSinceLastSettlement(), 0);
+        assertEq(orb.lastSettlementTime(), expectedSettlementTime);
+        uint256 owed = orb.workaround_owedSinceLastSettlement();
+
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, owed);
+        vm.prank(owner);
+        orb.setFees(200_00, 90_00, 90_00);
+        assertEq(orb.keeperTaxNumerator(), 200_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 90_00);
+        assertEq(orb.auctionRoyaltyNumerator(), 90_00);
+    }
+
+    function test_setFeesWhileOwnerHeld() public {
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 20_000_000);
+        orb.listWithPrice(1 ether);
+
+        assertTrue(orb.keeperTaxNumerator() != 200_00);
+        assertTrue(orb.purchaseRoyaltyNumerator() != 90_00);
+        assertTrue(orb.auctionRoyaltyNumerator() != 90_00);
+        assertGt(orb.honoredUntil(), block.timestamp);
+
+        vm.prank(owner);
+        orb.setFees(200_00, 90_00, 90_00);
+        assertEq(orb.keeperTaxNumerator(), 200_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 90_00);
+        assertEq(orb.auctionRoyaltyNumerator(), 90_00);
+    }
+
+    function test_previousFunctionSignatureNotSupported() public {
+        vm.prank(owner);
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.setFees(100_00, 10_00);
+    }
+}
+
+contract SettingMinimumPriceTest is OrbTestBase {
+    event MinimumPriceUpdate(uint256 previousMinimumPrice, uint256 indexed newMinimumPrice);
+
+    function test_setMinimumPriceOnlyOwnerControlled() public {
+        vm.prank(user);
+        vm.expectRevert("Ownable: caller is not the owner");
+        orb.setMinimumPrice(1 ether);
+
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        vm.expectRevert(Orb.AuctionRunning.selector);
+        orb.setMinimumPrice(1 ether);
+
+        prankAndBid(user, 1 ether);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+
+        vm.prank(owner);
+        vm.expectRevert(Orb.CreatorDoesNotControlOrb.selector);
+        orb.setMinimumPrice(1 ether);
+    }
+
+    function test_revertIfMinimumPriceTooHigh() public {
+        uint256 highPrice = orb.workaround_maximumPrice() + 1;
+        vm.expectRevert(abi.encodeWithSelector(Orb.InvalidNewPrice.selector, highPrice));
+        vm.prank(owner);
+        orb.setMinimumPrice(highPrice);
+
+        vm.prank(owner);
+        orb.setMinimumPrice(highPrice - 1);
+
+        assertEq(orb.minimumPrice(), orb.workaround_maximumPrice());
+    }
+
+    function test_setMinimumPriceSucceedsCorrectly() public {
+        assertEq(orb.minimumPrice(), 0);
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit MinimumPriceUpdate(0, 1 ether);
+
+        orb.setMinimumPrice(1 ether);
+        assertEq(orb.minimumPrice(), 1 ether);
+    }
+
+    event Settlement(address indexed keeper, address indexed beneficiary, uint256 indexed amount);
+
+    function test_succeedsIfOathExpired() public {
+        makeKeeperAndWarp(user, 1 ether);
+        vm.prank(user);
+        orb.deposit{value: 1000 ether}();
+        uint256 expectedSettlementTime = block.timestamp - 30 days;
+        assertGt(orb.workaround_owedSinceLastSettlement(), 0);
+        assertEq(orb.lastSettlementTime(), expectedSettlementTime);
+
+        assertGt(orb.honoredUntil(), block.timestamp);
+        vm.prank(owner);
+        vm.expectRevert(Orb.CreatorDoesNotControlOrb.selector);
+        orb.setMinimumPrice(1 ether);
+
+        assertEq(orb.minimumPrice(), 0);
+
+        vm.warp(orb.honoredUntil() + 1);
+        assertLt(orb.honoredUntil(), block.timestamp);
+        assertGt(orb.workaround_owedSinceLastSettlement(), 0);
+        assertEq(orb.lastSettlementTime(), expectedSettlementTime);
+        uint256 owed = orb.workaround_owedSinceLastSettlement();
+
+        vm.prank(owner);
+        orb.setMinimumPrice(1 ether);
+        assertEq(orb.minimumPrice(), 1 ether);
+    }
+
+    function test_setMinimumPriceWhileOwnerHeld() public {
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 20_000_000);
+        orb.listWithPrice(1 ether);
+
+        assertEq(orb.minimumPrice(), 0);
+        assertGt(orb.honoredUntil(), block.timestamp);
+
+        vm.prank(owner);
+        orb.setMinimumPrice(1 ether);
+        assertEq(orb.minimumPrice(), 1 ether);
+    }
+}
+
+contract SettingInvocationParametersTest is OrbTestBase {
+    event InvocationParametersUpdate(
+        uint256 previousCooldown,
+        uint256 indexed newCooldown,
+        uint256 previousResponsePeriod,
+        uint256 indexed newResponsePeriod,
+        uint256 previousFlaggingPeriod,
+        uint256 indexed newFlaggingPeriod,
+        uint256 previousCleartextMaximumLength,
+        uint256 newCleartextMaximumLength
+    );
+
+    function test_setInvocationParametersOnlyOwnerControlled() public {
+        vm.prank(user);
+        vm.expectRevert("Ownable: caller is not the owner");
+        orb.setInvocationParameters(1 days, 2 days, 3 days, 420);
+
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        vm.expectRevert(Orb.AuctionRunning.selector);
+        orb.setInvocationParameters(1 days, 2 days, 3 days, 420);
+
+        prankAndBid(user, 1 ether);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+
+        vm.prank(owner);
+        vm.expectRevert(Orb.CreatorDoesNotControlOrb.selector);
+        orb.setInvocationParameters(1 days, 2 days, 3 days, 420);
+    }
+
+    function test_revertsWhenCooldownTooLong() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(Orb.CooldownExceedsMaximumDuration.selector, 3651 days, 3650 days));
+        orb.setInvocationParameters(3651 days, 2 days, 3 days, 420);
+    }
+
+    function test_revertIfCleartextMaximumLengthZero() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(Orb.InvalidCleartextMaximumLength.selector, 0));
+        orb.setInvocationParameters(1 days, 2 days, 3 days, 0);
+    }
+
+    function test_setInvocationParametersSucceedsCorrectly() public {
+        assertEq(orb.cooldown(), 7 days);
+        assertEq(orb.responsePeriod(), 7 days);
+        assertEq(orb.flaggingPeriod(), 7 days);
+        assertEq(orb.cleartextMaximumLength(), 300);
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit InvocationParametersUpdate(7 days, 1 days, 7 days, 2 days, 7 days, 3 days, 300, 420);
+        orb.setInvocationParameters(1 days, 2 days, 3 days, 420);
+        assertEq(orb.cooldown(), 1 days);
+        assertEq(orb.responsePeriod(), 2 days);
+        assertEq(orb.flaggingPeriod(), 3 days);
+        assertEq(orb.cleartextMaximumLength(), 420);
+    }
+
+    function test_succeedsIfOathExpired() public {
+        makeKeeperAndWarp(user, 1 ether);
+
+        assertGt(orb.honoredUntil(), block.timestamp);
+        vm.prank(owner);
+        vm.expectRevert(Orb.CreatorDoesNotControlOrb.selector);
+        orb.setInvocationParameters(1 days, 2 days, 3 days, 420);
+
+        assertTrue(orb.cooldown() != 1 days);
+        assertTrue(orb.responsePeriod() != 2 days);
+        assertTrue(orb.flaggingPeriod() != 3 days);
+        assertTrue(orb.cleartextMaximumLength() != 420);
+
+        vm.warp(orb.honoredUntil() + 1);
+        assertLt(orb.honoredUntil(), block.timestamp);
+
+        vm.prank(owner);
+        orb.setInvocationParameters(1 days, 2 days, 3 days, 420);
+        assertEq(orb.cooldown(), 1 days);
+        assertEq(orb.responsePeriod(), 2 days);
+        assertEq(orb.flaggingPeriod(), 3 days);
+        assertEq(orb.cleartextMaximumLength(), 420);
+    }
+
+    function test_setInvocationParametersWhileOwnerHeld() public {
+        orb.swearOath(keccak256(abi.encodePacked("test oath")), 20_000_000);
+        orb.listWithPrice(1 ether);
+
+        assertTrue(orb.cooldown() != 1 days);
+        assertTrue(orb.responsePeriod() != 2 days);
+        assertTrue(orb.flaggingPeriod() != 3 days);
+        assertTrue(orb.cleartextMaximumLength() != 420);
+        assertGt(orb.honoredUntil(), block.timestamp);
+
+        vm.prank(owner);
+        orb.setInvocationParameters(1 days, 2 days, 3 days, 420);
+        assertEq(orb.cooldown(), 1 days);
+        assertEq(orb.responsePeriod(), 2 days);
+        assertEq(orb.flaggingPeriod(), 3 days);
+        assertEq(orb.cleartextMaximumLength(), 420);
+    }
+
+    function test_previousFunctionSignatureNotSupported() public {
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.setCleartextMaximumLength(256);
+
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.setCooldown(1 days, 2 days);
+    }
+}
+
+contract SettingBeneficiaryWithdrawalAddressTest is OrbTestBase {
+    event BeneficiaryWithdrawalAddressUpdate(
+        address previousBeneficiaryWithdrawalAddress, address indexed newBeneficiaryWithdrawalAddress
+    );
+
+    function test_revertsWhenNotOwner() public {
+        vm.prank(user);
+        vm.expectRevert("Ownable: caller is not the owner");
+        orb.setBeneficiaryWithdrawalAddress(address(0xBABEFACE));
+    }
+
+    function test_revertsWhenAddressNotPermitted() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(OrbV2.AddressNotPermitted.selector, address(address(0xBABEFACE))));
+        orb.setBeneficiaryWithdrawalAddress(address(0xBABEFACE));
+    }
+
+    function test_zeroAddressAlwaysPermitted() public {
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit BeneficiaryWithdrawalAddressUpdate(address(0), address(0));
+        orb.setBeneficiaryWithdrawalAddress(address(0));
+        assertEq(orb.beneficiaryWithdrawalAddress(), address(0));
+    }
+
+    event Settlement(address indexed keeper, address indexed beneficiary, uint256 indexed amount);
+    event Withdrawal(address indexed recipient, uint256 indexed amount);
+    event WithdrawalAddressAuthorization(address indexed withdrawalAddress, bool indexed authorized);
+
+    function test_succeedsCorrectly() public {
+        assertEq(orb.beneficiaryWithdrawalAddress(), address(0));
+        assertEq(orb.fundsOf(beneficiary), 0);
+
+        makeKeeperAndWarp(user, 1 ether);
+        // beneficiary now has funds from auction proceeeds, and from time since then
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, orb.workaround_owedSinceLastSettlement());
+        vm.expectEmit(true, true, true, true);
+        emit Withdrawal(beneficiary, orb.fundsOf(beneficiary) + orb.workaround_owedSinceLastSettlement());
+        vm.prank(user);
+        orb.withdrawAllForBeneficiary();
+
+        // setting to not permitted reverts
+        vm.expectRevert(abi.encodeWithSelector(OrbV2.AddressNotPermitted.selector, address(address(0xBABEFACE))));
+        vm.prank(owner);
+        orb.setBeneficiaryWithdrawalAddress(address(0xBABEFACE));
+
+        // new PaymentSplitter
+        address[] memory newSplitterPayees = new address[](2);
+        uint256[] memory newSplitterShares = new uint256[](2);
+        newSplitterPayees[0] = address(0xC0FFEE);
+        newSplitterPayees[1] = address(0xFACEB00C);
+        newSplitterShares[0] = 50;
+        newSplitterShares[1] = 50;
+        address newSplitter = ClonesUpgradeable.clone(address(paymentSplitterImplementation));
+        PaymentSplitter(payable(newSplitter)).initialize(newSplitterPayees, newSplitterShares);
+
+        assertEq(orbPond.beneficiaryWithdrawalAddressPermitted(newSplitter), false);
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawalAddressAuthorization(newSplitter, true);
+        orbPond.authorizeWithdrawalAddress(newSplitter, true);
+        assertEq(orbPond.beneficiaryWithdrawalAddressPermitted(newSplitter), true);
+
+        // now setting works
+        assertEq(orb.beneficiaryWithdrawalAddress(), address(0));
+        vm.expectEmit(true, true, true, true);
+        emit BeneficiaryWithdrawalAddressUpdate(address(0), newSplitter);
+        vm.prank(owner);
+        orb.setBeneficiaryWithdrawalAddress(newSplitter);
+        assertEq(orb.beneficiaryWithdrawalAddress(), newSplitter);
+
+        // now withdrawal happens to new address
+        vm.warp(block.timestamp + 30 days);
+        uint256 expectedBeneficiaryFunds = orb.workaround_owedSinceLastSettlement();
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, expectedBeneficiaryFunds);
+        orb.settle();
+        assertEq(orb.fundsOf(beneficiary), expectedBeneficiaryFunds);
+        assertEq(orb.fundsOf(newSplitter), 0);
+
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, 0);
+        vm.expectEmit(true, true, true, true);
+        emit Withdrawal(newSplitter, expectedBeneficiaryFunds);
+        vm.prank(user);
+        orb.withdrawAllForBeneficiary();
+
+        assertEq(orb.fundsOf(beneficiary), 0);
+        assertEq(orb.fundsOf(newSplitter), 0);
+
+        // test balance of newSplitter
+        assertEq(newSplitter.balance, expectedBeneficiaryFunds);
+        assertEq(PaymentSplitter(payable(newSplitter)).releasable(address(0xC0FFEE)), expectedBeneficiaryFunds / 2);
+        assertEq(PaymentSplitter(payable(newSplitter)).releasable(address(0xFACEB00C)), expectedBeneficiaryFunds / 2);
+    }
+
+    function test_settingToZeroAddressWithdrawsToBeneficiary() public {
+        assertEq(orb.beneficiaryWithdrawalAddress(), address(0));
+        assertEq(orb.fundsOf(beneficiary), 0);
+
+        // new PaymentSplitter
+        address[] memory newSplitterPayees = new address[](2);
+        uint256[] memory newSplitterShares = new uint256[](2);
+        newSplitterPayees[0] = address(0xC0FFEE);
+        newSplitterPayees[1] = address(0xFACEB00C);
+        newSplitterShares[0] = 50;
+        newSplitterShares[1] = 50;
+        address newSplitter = ClonesUpgradeable.clone(address(paymentSplitterImplementation));
+        PaymentSplitter(payable(newSplitter)).initialize(newSplitterPayees, newSplitterShares);
+        orbPond.authorizeWithdrawalAddress(newSplitter, true);
+        vm.prank(owner);
+        orb.setBeneficiaryWithdrawalAddress(newSplitter);
+        assertEq(orb.beneficiaryWithdrawalAddress(), newSplitter);
+
+        makeKeeperAndWarp(user, 1 ether);
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, orb.workaround_owedSinceLastSettlement());
+        vm.expectEmit(true, true, true, true);
+        emit Withdrawal(newSplitter, orb.fundsOf(beneficiary) + orb.workaround_owedSinceLastSettlement());
+        vm.prank(user);
+        orb.withdrawAllForBeneficiary();
+
+        vm.expectEmit(true, true, true, true);
+        emit BeneficiaryWithdrawalAddressUpdate(newSplitter, address(0));
+        vm.prank(owner);
+        orb.setBeneficiaryWithdrawalAddress(address(0));
+        assertEq(orb.beneficiaryWithdrawalAddress(), address(0));
+        uint256 originalSplitterBalanceBefore = beneficiary.balance;
+
+        // now withdrawal happens to original beneficiary
+        vm.warp(block.timestamp + 30 days);
+        uint256 expectedBeneficiaryFunds = orb.workaround_owedSinceLastSettlement();
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, expectedBeneficiaryFunds);
+        orb.settle();
+        assertEq(orb.fundsOf(beneficiary), expectedBeneficiaryFunds);
+
+        vm.expectEmit(true, true, true, true);
+        emit Settlement(user, beneficiary, 0);
+        vm.expectEmit(true, true, true, true);
+        emit Withdrawal(beneficiary, expectedBeneficiaryFunds);
+        vm.prank(user);
+        orb.withdrawAllForBeneficiary();
+
+        assertEq(orb.fundsOf(beneficiary), 0);
+        assertEq(orb.fundsOf(newSplitter), 0);
+        assertEq(beneficiary.balance, originalSplitterBalanceBefore + expectedBeneficiaryFunds);
+    }
+}

--- a/test/OrbV3/OrbV3-Upgrade.t.sol
+++ b/test/OrbV3/OrbV3-Upgrade.t.sol
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {Test} from "../../lib/forge-std/src/Test.sol";
+import {OrbHarness} from "./OrbV3Harness.sol";
+import {OrbTestBase} from "./OrbV3.t.sol";
+import {Orb} from "../../src/Orb.sol";
+import {OrbTestUpgrade} from "../../src/test-upgrades/OrbTestUpgrade.sol";
+
+/* solhint-disable func-name-mixedcase,private-vars-leading-underscore */
+contract RequestUpgradeTest is OrbTestBase {
+    event UpgradeRequest(address indexed requestedImplementation);
+
+    function test_revertWhenNotNextVersion() public {
+        assertEq(orb.requestedUpgradeImplementation(), address(0));
+        vm.expectRevert(Orb.NotNextVersion.selector);
+        vm.prank(owner);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+        assertEq(orb.requestedUpgradeImplementation(), address(0));
+
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+
+        vm.expectRevert(Orb.NotNextVersion.selector);
+        vm.prank(owner);
+        orb.requestUpgrade(address(0xCAFEBABE));
+        assertEq(orb.requestedUpgradeImplementation(), address(0));
+
+        vm.expectEmit(true, true, true, true);
+        emit UpgradeRequest(address(orbTestUpgradeImplementation));
+        vm.prank(owner);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+        assertEq(orb.requestedUpgradeImplementation(), address(orbTestUpgradeImplementation));
+    }
+
+    function test_ownerCanCancel() public {
+        assertEq(orb.requestedUpgradeImplementation(), address(0));
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+        vm.expectEmit(true, true, true, true);
+        emit UpgradeRequest(address(orbTestUpgradeImplementation));
+        vm.prank(owner);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+        assertEq(orb.requestedUpgradeImplementation(), address(orbTestUpgradeImplementation));
+
+        vm.expectEmit(true, true, true, true);
+        emit UpgradeRequest(address(0));
+        vm.prank(owner);
+        orb.requestUpgrade(address(0));
+        assertEq(orb.requestedUpgradeImplementation(), address(0));
+    }
+
+    function test_revertWhenNotOwner() public {
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+
+        assertEq(orb.requestedUpgradeImplementation(), address(0));
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(user);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+        assertEq(orb.requestedUpgradeImplementation(), address(0));
+
+        vm.expectEmit(true, true, true, true);
+        emit UpgradeRequest(address(orbTestUpgradeImplementation));
+        vm.prank(owner);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+        assertEq(orb.requestedUpgradeImplementation(), address(orbTestUpgradeImplementation));
+    }
+}
+
+contract CompleteUpgradeTest is OrbTestBase {
+    event Upgraded(address indexed implementation);
+
+    function test_revertWhenNotRequested() public {
+        makeKeeperAndWarp(user, 1 ether);
+        assertEq(orb.requestedUpgradeImplementation(), address(0));
+        vm.prank(user);
+        vm.expectRevert(Orb.NoUpgradeRequested.selector);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Orb");
+    }
+
+    function test_revertWhenNotKeeper() public {
+        makeKeeperAndWarp(user, 1 ether);
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+        vm.prank(owner);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+
+        assertEq(orb.requestedUpgradeImplementation(), address(orbTestUpgradeImplementation));
+        vm.expectRevert(Orb.NotPermitted.selector);
+        vm.prank(user2);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Orb");
+
+        vm.prank(user);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Whorb");
+    }
+
+    function test_revertWhenNotKeeperSolvent() public {
+        makeKeeperAndWarp(user, 1 ether);
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+        vm.prank(owner);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+        assertEq(orb.requestedUpgradeImplementation(), address(orbTestUpgradeImplementation));
+
+        vm.warp(block.timestamp + 10000 days);
+        vm.expectRevert(Orb.NotPermitted.selector);
+        vm.prank(user);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Orb");
+
+        vm.warp(block.timestamp - 10000 days);
+        vm.prank(user);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Whorb");
+    }
+
+    function test_revertWhenNotOwner() public {
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+        vm.prank(owner);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+        assertEq(orb.keeper(), address(orb));
+
+        vm.expectRevert(Orb.NotPermitted.selector);
+        vm.prank(user);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Orb");
+
+        vm.prank(owner);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Whorb");
+    }
+
+    function test_revertWhenAuctionRunning() public {
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+        vm.prank(owner);
+        orb.startAuction();
+
+        vm.prank(owner);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+
+        vm.expectRevert(Orb.NotPermitted.selector);
+        vm.prank(owner);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Orb");
+
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+
+        vm.prank(owner);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Whorb");
+    }
+
+    function test_revertWhenImplementationChanged() public {
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+        vm.prank(owner);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+
+        OrbTestUpgrade orbTestUpgradeAnotherImplementation = new OrbTestUpgrade();
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeAnotherImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+
+        vm.expectRevert(Orb.NotNextVersion.selector);
+        vm.prank(owner);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Orb");
+
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+        vm.prank(owner);
+        orb.upgradeToNextVersion();
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Whorb");
+    }
+
+    function test_upgradeSucceeds() public {
+        orbPond.registerVersion(
+            orb.version() + 1,
+            address(orbTestUpgradeImplementation),
+            abi.encodeWithSelector(OrbTestUpgrade.initializeTestUpgrade.selector, "Whorb", "WHORB")
+        );
+        vm.prank(owner);
+        orb.requestUpgrade(address(orbTestUpgradeImplementation));
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Orb");
+        assertEq(OrbTestUpgrade(address(orb)).symbol(), "ORB");
+        // Note: needs to be updated with every new base version
+        assertEq(OrbTestUpgrade(address(orb)).version(), 3);
+        assertEq(orb.requestedUpgradeImplementation(), address(orbTestUpgradeImplementation));
+
+        bytes4 numberSelector = bytes4(keccak256("number()"));
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool successBefore,) = address(orb).call(abi.encodeWithSelector(numberSelector));
+        assertEq(successBefore, false);
+
+        vm.expectEmit(true, true, true, true);
+        emit Upgraded(address(orbTestUpgradeImplementation));
+        vm.prank(owner);
+        orb.upgradeToNextVersion();
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool successAfter,) = address(orb).call(abi.encodeWithSelector(numberSelector));
+        assertEq(successAfter, true);
+        assertEq(OrbTestUpgrade(address(orb)).number(), 69);
+        assertEq(OrbTestUpgrade(address(orb)).name(), "Whorb");
+        assertEq(OrbTestUpgrade(address(orb)).symbol(), "WHORB");
+        assertEq(OrbTestUpgrade(address(orb)).version(), 100);
+
+        assertEq(orb.requestedUpgradeImplementation(), address(0));
+
+        vm.expectRevert("Initializable: contract is already initialized");
+        OrbTestUpgrade(address(orb)).initializeTestUpgrade("Error", "ERROR");
+    }
+}
+
+contract UpgradeFromV1Test is OrbTestBase {
+    function test_upgradeSucceeds() public {
+        orbPond.setOrbInitialVersion(1);
+
+        address[] memory beneficiaryPayees = new address[](2);
+        uint256[] memory beneficiaryShares = new uint256[](2);
+        beneficiaryPayees[0] = address(0xC0FFEE);
+        beneficiaryPayees[1] = address(0xFACEB00C);
+        beneficiaryShares[0] = 95;
+        beneficiaryShares[1] = 5;
+        orbPond.createOrb(beneficiaryPayees, beneficiaryShares, "Orb", "ORB", "https://static.orb.land/orb/");
+
+        assertEq(orbPond.orbCount(), 2);
+        Orb testOrbV1 = Orb(orbPond.orbs(1));
+
+        assertEq(testOrbV1.version(), 1);
+        assertEq(testOrbV1.responsePeriod(), 0);
+        assertEq(testOrbV1.royaltyNumerator(), 10_00);
+        bytes4 auctionRoyaltyNumeratorSelector = bytes4(keccak256("auctionRoyaltyNumerator()"));
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool successBefore,) = address(testOrbV1).call(abi.encodeWithSelector(auctionRoyaltyNumeratorSelector));
+        assertEq(successBefore, false);
+
+        testOrbV1.requestUpgrade(address(orbV2Implementation));
+        testOrbV1.upgradeToNextVersion();
+
+        OrbHarness testOrbV2 = OrbHarness(orbPond.orbs(1));
+
+        assertEq(testOrbV2.version(), 2);
+        assertEq(testOrbV2.responsePeriod(), 7 days);
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool successAfter,) = address(testOrbV2).call(abi.encodeWithSelector(auctionRoyaltyNumeratorSelector));
+        assertEq(successAfter, true);
+        assertEq(testOrbV2.auctionRoyaltyNumerator(), 10_00);
+    }
+}

--- a/test/OrbV3/OrbV3.t.sol
+++ b/test/OrbV3/OrbV3.t.sol
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+/* solhint-disable no-console */
+import {console} from "../../lib/forge-std/src/console.sol";
+import {Test} from "../../lib/forge-std/src/Test.sol";
+import {ERC1967Proxy} from "../../lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {PaymentSplitter} from "../../src/CustomPaymentSplitter.sol";
+import {OrbHarness} from "./OrbV3Harness.sol";
+import {OrbPond} from "../../src/OrbPond.sol";
+import {OrbPondV2} from "../../src/OrbPondV2.sol";
+import {OrbInvocationRegistry} from "../../src/OrbInvocationRegistry.sol";
+import {Orb} from "../../src/Orb.sol";
+import {OrbV2} from "../../src/OrbV2.sol";
+import {OrbV3} from "../../src/OrbV3.sol";
+import {OrbTestUpgrade} from "../../src/test-upgrades/OrbTestUpgrade.sol";
+
+/* solhint-disable func-name-mixedcase,private-vars-leading-underscore */
+contract OrbTestBase is Test {
+    PaymentSplitter internal paymentSplitterImplementation;
+
+    OrbInvocationRegistry internal orbInvocationRegistryImplementation;
+    OrbInvocationRegistry internal orbInvocationRegistry;
+
+    OrbPond internal orbPondV1Implementation;
+    OrbPondV2 internal orbPondV2Implementation;
+    OrbPondV2 internal orbPond;
+
+    Orb internal orbV1Implementation;
+    OrbV2 internal orbV2Implementation;
+    OrbHarness internal orbV3Implementation;
+    OrbTestUpgrade internal orbTestUpgradeImplementation;
+    OrbHarness internal orb;
+
+    address internal user;
+    address internal user2;
+    address internal beneficiary;
+    address internal owner;
+
+    uint256 internal startingBalance;
+
+    event Creation();
+
+    function setUp() public {
+        user = address(0xBEEF);
+        user2 = address(0xFEEEEEB);
+
+        startingBalance = 10_000 ether;
+        vm.deal(user, startingBalance);
+        vm.deal(user2, startingBalance);
+
+        orbInvocationRegistryImplementation = new OrbInvocationRegistry();
+        orbPondV1Implementation = new OrbPond();
+        orbPondV2Implementation = new OrbPondV2();
+        orbV1Implementation = new Orb();
+        orbV2Implementation = new OrbV2();
+        orbV3Implementation = new OrbHarness();
+        orbTestUpgradeImplementation = new OrbTestUpgrade();
+        paymentSplitterImplementation = new PaymentSplitter();
+
+        ERC1967Proxy orbInvocationRegistryProxy = new ERC1967Proxy(
+            address(orbInvocationRegistryImplementation),
+            abi.encodeWithSelector(OrbInvocationRegistry.initialize.selector)
+        );
+        orbInvocationRegistry = OrbInvocationRegistry(address(orbInvocationRegistryProxy));
+
+        ERC1967Proxy orbPondProxy = new ERC1967Proxy(
+            address(orbPondV1Implementation),
+            abi.encodeWithSelector(
+                OrbPond.initialize.selector, address(orbInvocationRegistry), address(paymentSplitterImplementation)
+            )
+        );
+        bytes memory orbInitializeCalldata = abi.encodeWithSelector(Orb.initialize.selector, address(0), "", "", "");
+        OrbPond(address(orbPondProxy)).registerVersion(1, address(orbV1Implementation), orbInitializeCalldata);
+
+        OrbPond(address(orbPondProxy)).upgradeToAndCall(
+            address(orbPondV2Implementation), abi.encodeWithSelector(OrbPondV2.initializeV2.selector, 1)
+        );
+        orbPond = OrbPondV2(address(orbPondProxy));
+        bytes memory orbV2InitializeCalldata = abi.encodeWithSelector(OrbV2.initializeV2.selector);
+        bytes memory orbV3InitializeCalldata = abi.encodeWithSelector(OrbV3.initializeV3.selector);
+        orbPond.registerVersion(2, address(orbV2Implementation), orbV2InitializeCalldata);
+        orbPond.registerVersion(3, address(orbV3Implementation), orbV3InitializeCalldata);
+        orbPond.setOrbInitialVersion(3);
+
+        address[] memory beneficiaryPayees = new address[](2);
+        uint256[] memory beneficiaryShares = new uint256[](2);
+        beneficiaryPayees[0] = address(0xC0FFEE);
+        beneficiaryPayees[1] = address(0xFACEB00C);
+        beneficiaryShares[0] = 95;
+        beneficiaryShares[1] = 5;
+
+        vm.expectEmit(true, true, true, true);
+        emit Creation();
+        orbPond.createOrb(beneficiaryPayees, beneficiaryShares, "Orb", "ORB", "https://static.orb.land/orb/");
+
+        orb = OrbHarness(orbPond.orbs(0));
+        beneficiary = orb.beneficiary();
+
+        orb.swearOath(
+            keccak256(abi.encodePacked("test oath")), // oathHash
+            20_000_000 // honoredUntil
+        );
+        orb.setAuctionParameters(0.1 ether, 0.1 ether, 1 days, 6 hours, 5 minutes);
+        owner = orb.owner();
+    }
+
+    function prankAndBid(address bidder, uint256 bidAmount) internal {
+        uint256 finalAmount = fundsRequiredToBidOneYear(bidAmount);
+        vm.deal(bidder, startingBalance + finalAmount);
+        vm.prank(bidder);
+        orb.bid{value: finalAmount}(bidAmount, bidAmount);
+    }
+
+    function makeKeeperAndWarp(address newKeeper, uint256 bid) public {
+        orb.startAuction();
+        prankAndBid(newKeeper, bid);
+        vm.warp(orb.auctionEndTime() + 1);
+        orb.finalizeAuction();
+        vm.warp(block.timestamp + 30 days);
+    }
+
+    function fundsRequiredToBidOneYear(uint256 amount) public view returns (uint256) {
+        return amount + (amount * orb.keeperTaxNumerator()) / orb.feeDenominator();
+    }
+
+    function effectiveFundsOf(address user_) public view returns (uint256) {
+        uint256 unadjustedFunds = orb.fundsOf(user_);
+        address keeper = orb.keeper();
+
+        if (user_ == orb.owner()) {
+            return unadjustedFunds;
+        }
+
+        if (user_ == beneficiary || user_ == keeper) {
+            uint256 owedFunds = orb.workaround_owedSinceLastSettlement();
+            uint256 keeperFunds = orb.fundsOf(keeper);
+            uint256 transferableToBeneficiary = keeperFunds <= owedFunds ? keeperFunds : owedFunds;
+
+            if (user_ == beneficiary) {
+                return unadjustedFunds + transferableToBeneficiary;
+            }
+            if (user_ == keeper) {
+                return unadjustedFunds - transferableToBeneficiary;
+            }
+        }
+
+        return unadjustedFunds;
+    }
+}
+
+contract InitialStateTest is OrbTestBase {
+    // Test that the initial state is correct
+    function test_initialState() public {
+        // Note: needs to be updated with every new version
+        assertEq(orb.version(), 3);
+        assertEq(address(orb), orb.keeper());
+        assertFalse(orb.workaround_auctionRunning());
+        assertEq(orb.pond(), address(orbPond));
+        assertEq(orb.owner(), address(this));
+        assertEq(orb.beneficiary(), beneficiary);
+        assertEq(orb.beneficiaryWithdrawalAddress(), address(0));
+        assertEq(orb.honoredUntil(), 20_000_000);
+
+        assertEq(PaymentSplitter(payable(orb.beneficiary())).totalShares(), 100);
+        assertEq(PaymentSplitter(payable(orb.beneficiary())).totalReleased(), 0);
+        assertEq(PaymentSplitter(payable(orb.beneficiary())).shares(address(0xC0FFEE)), 95);
+        assertEq(PaymentSplitter(payable(orb.beneficiary())).shares(address(0xFACEB00C)), 5);
+
+        assertEq(orb.name(), "Orb");
+        assertEq(orb.symbol(), "ORB");
+
+        assertEq(orb.workaround_tokenURI(), "https://static.orb.land/orb/");
+
+        assertEq(orb.cleartextMaximumLength(), 300);
+
+        assertEq(orb.price(), 0);
+        assertEq(orb.keeperTaxNumerator(), 120_00);
+        assertEq(orb.purchaseRoyaltyNumerator(), 10_00);
+        assertEq(orb.auctionRoyaltyNumerator(), 30_00);
+        assertEq(orb.lastInvocationTime(), 0);
+        assertEq(orb.minimumPrice(), 0);
+
+        assertEq(orb.auctionStartingPrice(), 0.1 ether);
+        assertEq(orb.auctionMinimumBidStep(), 0.1 ether);
+        assertEq(orb.auctionMinimumDuration(), 1 days);
+        assertEq(orb.auctionKeeperMinimumDuration(), 6 hours);
+        assertEq(orb.auctionBidExtension(), 5 minutes);
+
+        assertEq(orb.cooldown(), 7 days);
+        assertEq(orb.responsePeriod(), 7 days);
+        assertEq(orb.flaggingPeriod(), 7 days);
+
+        assertEq(orb.auctionBeneficiary(), address(0));
+        assertEq(orb.auctionEndTime(), 0);
+        assertEq(orb.leadingBidder(), address(0));
+        assertEq(orb.leadingBid(), 0);
+
+        assertEq(orb.lastSettlementTime(), 0);
+        assertEq(orb.keeperReceiveTime(), 0);
+        assertEq(orb.requestedUpgradeImplementation(), address(0));
+    }
+
+    function test_constants() public {
+        assertEq(orb.feeDenominator(), 100_00);
+        assertEq(orb.keeperTaxPeriod(), 365 days);
+
+        assertEq(orb.workaround_maximumPrice(), 2 ** 128);
+        assertEq(orb.workaround_cooldownMaximumDuration(), 3650 days);
+    }
+
+    function test_revertsInitializer() public {
+        vm.expectRevert("Initializable: contract is already initialized");
+        orb.initialize(address(0), "", "", "");
+    }
+
+    function test_revertsV2Initializer() public {
+        vm.expectRevert("Initializable: contract is already initialized");
+        orb.initializeV2();
+    }
+
+    function test_revertsV3Initializer() public {
+        vm.expectRevert("Initializable: contract is already initialized");
+        orb.initializeV3();
+    }
+
+    function test_initializerSuccess() public {
+        ERC1967Proxy orbProxy = new ERC1967Proxy(address(orbV3Implementation), "");
+        Orb _orb = Orb(address(orbProxy));
+        assertEq(_orb.owner(), address(0));
+        _orb.initialize(address(0xC0FFEE), "name", "symbol", "tokenURI");
+        assertEq(_orb.owner(), address(this));
+    }
+}
+
+contract SupportsInterfaceTest is OrbTestBase {
+    // Test that the initial state is correct
+    function test_supportsInterface() public view {
+        // console.logBytes4(type(Orb).interfaceId);
+        assert(orb.supportsInterface(0x01ffc9a7)); // ERC165 Interface ID for ERC165
+        assert(orb.supportsInterface(0x80ac58cd)); // ERC165 Interface ID for ERC721
+        assert(orb.supportsInterface(0x5b5e139f)); // ERC165 Interface ID for ERC721Metadata
+        assert(orb.supportsInterface(0x4645e06f)); // ERC165 Interface ID for Orb
+    }
+}
+
+contract ERC721Test is OrbTestBase {
+    // tokenURI
+
+    function test_erc721BalanceOf() public {
+        assertEq(orb.balanceOf(address(orb)), 1);
+        assertEq(orb.balanceOf(user), 0);
+        makeKeeperAndWarp(user, 1 ether);
+        assertEq(orb.balanceOf(address(orb)), 0);
+        assertEq(orb.balanceOf(user), 1);
+    }
+
+    function test_erc721OwnerOf() public {
+        assertEq(orb.ownerOf(1), address(orb));
+        makeKeeperAndWarp(user, 1 ether);
+        assertEq(orb.ownerOf(1), user);
+    }
+
+    function test_erc721TokenURI() public {
+        assertEq(orb.tokenURI(1), "https://static.orb.land/orb/");
+        assertEq(orb.tokenURI(69), "https://static.orb.land/orb/");
+    }
+
+    function test_erc721FunctionsRevert() public {
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.approve(address(0), 1);
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.setApprovalForAll(address(0), true);
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.getApproved(0);
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.isApprovedForAll(address(0), owner);
+    }
+
+    function test_transfersRevert() public {
+        address newOwner = address(0xBEEF);
+        uint256 tokenId = 1;
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.transferFrom(address(this), newOwner, tokenId);
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.safeTransferFrom(address(this), newOwner, tokenId);
+        vm.expectRevert(Orb.NotSupported.selector);
+        orb.safeTransferFrom(address(this), newOwner, tokenId, bytes(""));
+    }
+}
+
+contract OrbInvocationRegistrySupportTest is OrbTestBase {
+    function test_setLastInvocationTime() public {
+        assertEq(orb.lastInvocationTime(), 0);
+        vm.expectRevert(Orb.NotPermitted.selector);
+        orb.setLastInvocationTime(42);
+        assertEq(orb.lastInvocationTime(), 0);
+
+        vm.prank(address(orbInvocationRegistry));
+        orb.setLastInvocationTime(42);
+        assertEq(orb.lastInvocationTime(), 42);
+    }
+}

--- a/test/OrbV3/OrbV3Harness.sol
+++ b/test/OrbV3/OrbV3Harness.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {OrbV3} from "../../src/OrbV3.sol";
+
+/* solhint-disable func-name-mixedcase */
+contract OrbHarness is OrbV3 {
+    function workaround_cooldownMaximumDuration() public pure returns (uint256) {
+        return _COOLDOWN_MAXIMUM_DURATION;
+    }
+
+    function workaround_maximumPrice() public pure returns (uint256) {
+        return _MAXIMUM_PRICE;
+    }
+
+    function workaround_tokenURI() public view returns (string memory) {
+        return _tokenURI;
+    }
+
+    function workaround_auctionRunning() public view returns (bool) {
+        return _auctionRunning();
+    }
+
+    function workaround_minimumBid() public view returns (uint256) {
+        return _minimumBid();
+    }
+
+    function workaround_setPrice(uint256 _price) public {
+        price = _price;
+    }
+
+    function workaround_setLastSettlementTime(uint256 time) public {
+        lastSettlementTime = time;
+    }
+
+    function workaround_setOrbKeeper(address keeper_) public {
+        _transferOrb(keeper, keeper_);
+    }
+
+    function workaround_owedSinceLastSettlement() public view returns (uint256) {
+        return _owedSinceLastSettlement();
+    }
+
+    function workaround_settle() public {
+        _settle();
+    }
+}


### PR DESCRIPTION
- Adds an owner method setMinimumPrice to set the lowest price that Orb can be sold at
- Limits Orb price setting to respect the new setting