### PR TITLE
Purchase Orders

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,7 +9,7 @@ remappings = [ # Libraries that we use from node_modules and are used by the sma
 ]
 # viaIR = true
 optimizer = true             # Enable or disable the solc optimizer
-optimizer_runs = 2_000       # The number of optimizer runs
+optimizer_runs = 10_000_000  # The number of optimizer runs
 verbosity = 3                # The verbosity of tests
 bytecode_hash = "none"       # For deterministic code
 block_timestamp = 10_000_000 # Timestamp for tests (non-zero)

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,7 +9,7 @@ remappings = [ # Libraries that we use from node_modules and are used by the sma
 ]
 # viaIR = true
 optimizer = true             # Enable or disable the solc optimizer
-optimizer_runs = 10_000_000  # The number of optimizer runs
+optimizer_runs = 100_000     # The number of optimizer runs
 verbosity = 3                # The verbosity of tests
 bytecode_hash = "none"       # For deterministic code
 block_timestamp = 10_000_000 # Timestamp for tests (non-zero)

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,7 +9,7 @@ remappings = [ # Libraries that we use from node_modules and are used by the sma
 ]
 # viaIR = true
 optimizer = true             # Enable or disable the solc optimizer
-optimizer_runs = 10_000_000  # The number of optimizer runs
+optimizer_runs = 2_000       # The number of optimizer runs
 verbosity = 3                # The verbosity of tests
 bytecode_hash = "none"       # For deterministic code
 block_timestamp = 10_000_000 # Timestamp for tests (non-zero)

--- a/src/Earnable.sol
+++ b/src/Earnable.sol
@@ -18,12 +18,10 @@ abstract contract Earnable is ContextUpgradeable {
     /// - Harberger tax revenue.
     mapping(address user => uint256 earnings) public earningsOf;
 
-    function _platformFee() internal virtual returns (uint256);
-    function _feeDenominator() internal virtual returns (uint256);
     function _earningsWithdrawalAddress(address) internal virtual returns (address);
 
     function _addEarnings(address user, uint256 amount) internal {
-        uint256 platformShare = (amount * _platformFee()) / _feeDenominator();
+        uint256 platformShare = (amount * 5_00) / 100_00;
         uint256 userShare = amount - platformShare;
 
         earningsOf[address(0)] += platformShare;

--- a/src/HarbergerTaxKeepership.sol
+++ b/src/HarbergerTaxKeepership.sol
@@ -1,0 +1,543 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import {OwnableUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import {UUPSUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {Address} from "../lib/openzeppelin-contracts/contracts/utils/Address.sol";
+import {OrbSystem} from "./OrbSystem.sol";
+import {OwnershipRegistry} from "./OwnershipRegistry.sol";
+import {InvocationRegistry} from "./InvocationRegistry.sol";
+
+import {Earnable} from "./Earnable.sol";
+
+struct PurchaseOrder {
+    uint256 index; // starts from 0, so shouldn't be used to check if the order exists
+    address purchaser;
+    uint256 price; // price if finalized
+    uint256 timestamp; // when the order was placed
+}
+
+/// @title   Harberger Tax Keepership
+/// @author  Jonas Lekevicius
+/// @custom:security-contact security@orb.land
+contract HarbergerTaxKeepership is Earnable, OwnableUpgradeable, UUPSUpgradeable {
+    // Funding Events
+    event Deposit(uint256 indexed orbId, address indexed depositor, uint256 amount);
+    event Withdrawal(uint256 indexed orbId, address indexed recipient, uint256 amount);
+    event Settlement(uint256 indexed orbId, address indexed keeper, uint256 amount);
+
+    event Purchase(uint256 indexed orbId, address indexed seller, address indexed buyer, uint256 price);
+    event PurchaseOrderPlacement(uint256 indexed orbId, address indexed purchaser, uint256 price);
+    event PurchaseFinalization(uint256 indexed orbId, address indexed seller, address indexed buyer, uint256 price);
+    event PurchaseCancellation(uint256 indexed orbId);
+
+    error InsufficientFunds(uint256 fundsAvailable, uint256 fundsRequired);
+    // Purchasing Errors
+    error CurrentValueIncorrect(uint256 valueProvided, uint256 currentValue);
+    error PurchasingNotPermitted();
+    error AlreadyKeeper();
+    error AlreadyLastPurchaser();
+    error NoPurchaseOrder();
+    error PurchaseOrderExpired();
+    error OrbInvokable();
+    error InsufficientKeeperFunds();
+    error OrbNotInvokable();
+    error NotPermitted();
+    error NotKeeper();
+    error KeeperInsolvent();
+    error OrbDoesNotExist();
+    error ContractHoldsOrb();
+
+    /// Orb version. Value: 1.
+    uint256 private constant _VERSION = 1;
+    /// Harberger tax period: for how long the tax rate applies. Value: 1 year.
+    uint256 internal constant _KEEPER_TAX_PERIOD = 365 days;
+    /// Next purchase order price multiplier. Value: 1.2x of the previous price.
+    uint256 internal constant _NEXT_PURCHASE_PRICE_MULTIPLIER = 120_00;
+
+    OrbSystem public os;
+    OwnershipRegistry public ownershipRegistry;
+
+    // Funds Variables
+
+    /// Funds tracker, per Orb and per address. Modified by deposits, withdrawals and settlements.
+    /// The value is without settlement.
+    /// It means effective user funds (withdrawable) would be different for keeper (subtracting
+    /// `_owedSinceLastSettlement()`) and beneficiary (adding `_owedSinceLastSettlement()`). If Orb is held by the
+    /// creator, funds are not subtracted, as Harberger tax does not apply to the creator.
+    mapping(uint256 orbId => mapping(address => uint256)) public fundsOf;
+
+    /// Last time Orb keeper's funds were settled. Used to calculate amount owed since last settlement. Has no meaning
+    /// if the Orb is held by the contract.
+    mapping(uint256 orbId => uint256) public lastSettlementTime;
+
+    mapping(uint256 orbId => PurchaseOrder) public purchaseOrder;
+
+    modifier onlyOwnershipContract() {
+        if (_msgSender() != address(ownershipRegistry)) {
+            revert NotPermitted();
+        }
+        _;
+    }
+
+    /// @dev  Ensures that the caller owns the Orb. Should only be used in conjuction with `onlyKeeperHeld` or on
+    ///       external functions, otherwise does not make sense.
+    modifier onlyKeeper(uint256 orbId) virtual {
+        if (_msgSender() != ownershipRegistry.keeper(orbId)) {
+            revert NotKeeper();
+        }
+        if (_keeperSolvent(orbId) == false) {
+            revert KeeperInsolvent();
+        }
+        _;
+    }
+
+    // ORB STATE MODIFIERS
+
+    /// @dev  Ensures that the Orb belongs to someone (possibly creator), not the contract itself.
+    modifier onlyKeeperHeld(uint256 orbId) virtual {
+        if (address(0) == ownershipRegistry.keeper(orbId)) {
+            revert OrbDoesNotExist();
+        }
+        if (address(this) == ownershipRegistry.keeper(orbId)) {
+            revert ContractHoldsOrb();
+        }
+        _;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //  INITIALIZER AND INTERFACE SUPPORT
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initalize(address os_) public initializer {
+        __Ownable_init(_msgSender());
+        __UUPSUpgradeable_init();
+
+        os = OrbSystem(os_);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //  FUNCTIONS: FUNDS AND HOLDING
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// @notice  Allows depositing funds on the contract. Not allowed for insolvent keepers.
+    /// @dev     Deposits are not allowed for insolvent keepers to prevent cheating via front-running. If the user
+    ///          becomes insolvent, the Orb will always be returned to the contract as the next step. Emits `Deposit`.
+    function deposit(uint256 orbId) external payable virtual {
+        if (_msgSender() == ownershipRegistry.keeper(orbId) && !_keeperSolvent(orbId)) {
+            revert KeeperInsolvent();
+        }
+
+        fundsOf[orbId][_msgSender()] += msg.value;
+        emit Deposit(orbId, _msgSender(), msg.value);
+    }
+
+    /// @notice  Function to withdraw given amount from the contract. For current Orb keepers, reduces the time until
+    ///          foreclosure.
+    /// @dev     Not allowed for the leading auction bidder.
+    /// @param   amount_  The amount to withdraw.
+    function withdraw(uint256 orbId, uint256 amount_) external virtual {
+        if (_msgSender() == ownershipRegistry.keeper(orbId)) {
+            if (purchaseOrder[orbId].purchaser != address(0)) {
+                revert NotPermitted();
+            }
+            _settle(orbId);
+        }
+        _withdraw(orbId, _msgSender(), amount_);
+    }
+
+    /// @notice  Function to withdraw all funds on the contract. Not recommended for current Orb keepers if the price
+    ///          is not zero, as they will become immediately foreclosable. To give up the Orb, call `relinquish()`.
+    /// @dev     Not allowed for the leading auction bidder.
+    function withdrawAll(uint256 orbId) external virtual {
+        if (_msgSender() == ownershipRegistry.keeper(orbId)) {
+            if (purchaseOrder[orbId].purchaser != address(0)) {
+                revert NotPermitted();
+            }
+            _settle(orbId);
+        }
+        _withdraw(orbId, _msgSender(), fundsOf[orbId][_msgSender()]);
+    }
+
+    function withdrawAllFor(uint256 orbId, address recipient) external virtual onlyOwnershipContract {
+        _withdraw(orbId, recipient, fundsOf[orbId][recipient]);
+    }
+
+    /// @dev    Executes the withdrawal for a given amount, does the actual value transfer from the contract to user's
+    ///         wallet. The only function in the contract that sends value and has re-entrancy risk. Does not check if
+    ///         the address is payable, as the Address library reverts if it is not. Emits `Withdrawal`.
+    /// @param  recipient_  The address to send the value to.
+    /// @param  amount_     The value in wei to withdraw from the contract.
+    function _withdraw(uint256 orbId, address recipient_, uint256 amount_) internal virtual {
+        if (fundsOf[orbId][recipient_] < amount_) {
+            revert InsufficientFunds(fundsOf[orbId][recipient_], amount_);
+        }
+
+        fundsOf[orbId][recipient_] -= amount_;
+
+        emit Withdrawal(orbId, recipient_, amount_);
+
+        Address.sendValue(payable(recipient_), amount_);
+    }
+
+    function keeperTaxPeriod() external pure virtual returns (uint256) {
+        return _KEEPER_TAX_PERIOD;
+    }
+
+    function hasPurchaseOrder(uint256 orbId) external view virtual returns (bool) {
+        return purchaseOrder[orbId].purchaser != address(0);
+    }
+
+    /// @notice  Settlements transfer funds from Orb keeper to the beneficiary. Orb accounting minimizes required
+    ///          transactions: Orb keeper's foreclosure time is only dependent on the price and available funds. Fund
+    ///          transfers are not necessary unless these variables (price, keeper funds) are being changed. Settlement
+    ///          transfers funds owed since the last settlement, and a new period of virtual accounting begins.
+    /// @dev     See also `_settle()`.
+    function settle(uint256 orbId) external virtual onlyKeeperHeld(orbId) {
+        _settle(orbId);
+    }
+
+    /// @dev     Returns if the current Orb keeper has enough funds to cover Harberger tax until now. Always true if
+    ///          creator holds the Orb.
+    /// @return  isKeeperSolvent  If the current keeper is solvent.
+    function _keeperSolvent(uint256 orbId) internal view virtual returns (bool) {
+        if (ownershipRegistry.creator(orbId) == ownershipRegistry.keeper(orbId)) {
+            return true;
+        }
+        return fundsOf[orbId][ownershipRegistry.keeper(orbId)] >= _owedSinceLastSettlement(orbId);
+    }
+
+    function keeperSolvent(uint256 orbId) external view virtual returns (bool isKeeperSolvent) {
+        return _keeperSolvent(orbId);
+    }
+
+    function _foreclosureTimestamp(uint256 orbId) internal view virtual returns (uint256) {
+        if (
+            ownershipRegistry.creator(orbId) == ownershipRegistry.keeper(orbId)
+                || ownershipRegistry.keeper(orbId) == address(this) || ownershipRegistry.price(orbId) == 0
+                || ownershipRegistry.keeperTax(orbId) == 0
+        ) {
+            return type(uint256).max;
+        }
+        uint256 owedFunds = _owedSinceLastSettlement(orbId);
+        uint256 availableFunds = fundsOf[orbId][ownershipRegistry.keeper(orbId)];
+        uint256 effectiveFunds = availableFunds <= owedFunds ? 0 : availableFunds - owedFunds;
+        return effectiveFunds * _KEEPER_TAX_PERIOD * os.feeDenominator()
+            / (ownershipRegistry.price(orbId) * ownershipRegistry.keeperTax(orbId));
+    }
+
+    /// @dev     Calculates how much money Orb keeper owes Orb beneficiary. This amount would be transferred between
+    ///          accounts during settlement. **Owed amount can be higher than keeper's funds!** It's important to check
+    ///          if keeper has enough funds before transferring.
+    /// @return  owedValue  Wei Orb keeper owes Orb beneficiary since the last settlement time.
+    function _owedSinceLastSettlement(uint256 orbId) internal view virtual returns (uint256 owedValue) {
+        uint256 taxedUntil = block.timestamp;
+        InvocationRegistry invocations = os.invocations();
+
+        // Settles during response, so we only need to account for pause if an invocation has no response
+        if (invocations.hasUnrespondedInvocation(orbId)) {
+            uint256 invocationTimestamp = invocations.lastInvocationTime(orbId);
+            uint256 invocationPeriod = invocations.invocationPeriod(orbId);
+            if (block.timestamp > invocationTimestamp + invocationPeriod) {
+                taxedUntil = invocationTimestamp + invocationPeriod;
+            }
+        }
+        uint256 secondsSinceLastSettlement =
+            taxedUntil > lastSettlementTime[orbId] ? taxedUntil - lastSettlementTime[orbId] : 0;
+        return (ownershipRegistry.price(orbId) * ownershipRegistry.keeperTax(orbId) * secondsSinceLastSettlement)
+            / (_KEEPER_TAX_PERIOD * os.feeDenominator());
+    }
+
+    /// @dev  Keeper might owe more than they have funds available: it means that the keeper is foreclosable.
+    ///       Settlement would transfer all keeper funds to the beneficiary, but not more. Does not transfer funds if
+    ///       the creator holds the Orb, but always updates `lastSettlementTime`. Should never be called if Orb is
+    ///       owned by the contract. Emits `Settlement`.
+    function _settle(uint256 orbId) internal virtual {
+        address _keeper = ownershipRegistry.keeper(orbId);
+        address _creator = ownershipRegistry.creator(orbId);
+
+        if (_creator == _keeper) {
+            lastSettlementTime[orbId] = block.timestamp;
+            return;
+        }
+
+        uint256 availableFunds = fundsOf[orbId][_keeper];
+        uint256 owedFunds = _owedSinceLastSettlement(orbId);
+        uint256 transferableToEarnings = availableFunds <= owedFunds ? availableFunds : owedFunds;
+
+        fundsOf[orbId][_keeper] -= transferableToEarnings;
+        _addEarnings(_creator, transferableToEarnings);
+
+        lastSettlementTime[orbId] = block.timestamp;
+
+        emit Settlement(orbId, _keeper, transferableToEarnings);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //  FUNCTIONS: PURCHASING AND LISTING
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// @notice  Purchasing is the mechanism to take over the Orb. With Harberger tax, the Orb can always be purchased
+    ///          from its keeper. Purchasing is only allowed while the keeper is solvent. If not, the Orb has to be
+    ///          foreclosed and re-auctioned. This function does not require the purchaser to have more funds than
+    ///          required, but purchasing without any reserve would leave the new owner immediately foreclosable.
+    ///          Beneficiary receives either just the royalty, or full price if the Orb is purchased from the creator.
+    /// @dev     Requires to provide key Orb parameters (current price, Harberger tax rate, royalty, invocationPeriod
+    ///          and cleartext maximum length) to prevent front-running: without these parameters Orb creator could
+    ///          front-run purcaser and change Orb parameters before the purchase; and without current price anyone
+    ///          could purchase the Orb ahead of the purchaser, set the price higher, and profit from the purchase.
+    ///          Does not modify `lastInvocationTime` unless buying from the creator.
+    ///          Does not allow settlement in the same block before `purchase()` to prevent transfers that avoid
+    ///          royalty payments. Does not allow purchasing from yourself. Emits `PriceUpdate` and `Purchase`.
+    ///          V2 changes to require providing Keeper auction royalty to prevent front-running.
+    /// @param  orbId      ID of the Orb to purchase.
+    /// @param  newPrice_  New price to use after the purchase.
+    function purchase(uint256 orbId, uint256 newPrice_) external payable virtual onlyKeeperHeld(orbId) {
+        if (_keeperSolvent(orbId) == false) {
+            revert KeeperInsolvent();
+        }
+        if (lastSettlementTime[orbId] >= block.timestamp) {
+            revert PurchasingNotPermitted();
+        }
+
+        _settle(orbId);
+
+        address _keeper = ownershipRegistry.keeper(orbId);
+        address _creator = ownershipRegistry.creator(orbId);
+        // how much you have to pay now:
+        uint256 _currentPrice = _nextPurchaseOrderPrice(orbId);
+        // might be 0 if there isn't a purchase order:
+        uint256 _lastOrderPrice = _lastPurchaseOrderPrice(orbId);
+
+        if (_msgSender() == _keeper) {
+            revert AlreadyKeeper();
+        }
+
+        fundsOf[orbId][_msgSender()] += msg.value;
+        uint256 totalFunds = fundsOf[orbId][_msgSender()];
+
+        if (totalFunds < _currentPrice) {
+            revert InsufficientFunds(totalFunds, _currentPrice);
+        }
+
+        fundsOf[orbId][_msgSender()] -= _currentPrice;
+        address _lastPurchaser = purchaseOrder[orbId].purchaser;
+        uint256 _keeperEarnings = _currentPrice;
+        if (_lastPurchaser != address(0)) {
+            // last order price will not be 0
+            // maker of last purchase order earns the difference as usual
+            _addEarnings(_lastPurchaser, _currentPrice - _lastOrderPrice);
+            // they also get refund for the purchase order funds that were standing
+            fundsOf[orbId][_lastPurchaser] += _lastOrderPrice;
+            _keeperEarnings = _lastOrderPrice;
+            _resetPurchaseOrder(orbId);
+        }
+        if (_creator == _keeper) {
+            os.invocations().initializeOrbInvocationPeriod(orbId);
+            // if there was a purchase order, it should get the _purchaseOrderFunds
+            // if not, it should get keeper price
+            _addEarnings(_creator, _keeperEarnings);
+        } else {
+            uint256 royaltyShare = (_keeperEarnings * ownershipRegistry.purchaseRoyalty(orbId)) / os.feeDenominator();
+            _addEarnings(_creator, royaltyShare);
+            _addEarnings(_keeper, _keeperEarnings - royaltyShare);
+        }
+
+        _setPrice(orbId, newPrice_);
+
+        emit Purchase(orbId, _keeper, _msgSender(), _currentPrice);
+
+        ownershipRegistry.setKeeper(orbId, _msgSender());
+    }
+
+    function _setPrice(uint256 orbId, uint256 newPrice_) internal virtual {
+        ownershipRegistry.setPriceInternal(orbId, newPrice_);
+    }
+
+    function _nextPurchaseOrderPrice(uint256 orbId) internal view virtual returns (uint256) {
+        if (purchaseOrder[orbId].purchaser != address(0)) {
+            return ownershipRegistry.price(orbId)
+                * (_NEXT_PURCHASE_PRICE_MULTIPLIER ** (purchaseOrder[orbId].index + 1)) / os.feeDenominator();
+        }
+        return ownershipRegistry.price(orbId);
+    }
+
+    function _lastPurchaseOrderPrice(uint256 orbId) internal view virtual returns (uint256) {
+        if (purchaseOrder[orbId].purchaser != address(0)) {
+            // uses index before updating during purchase order
+            return ownershipRegistry.price(orbId) * (_NEXT_PURCHASE_PRICE_MULTIPLIER ** purchaseOrder[orbId].index)
+                / os.feeDenominator();
+        }
+        return 0;
+    }
+
+    function nextPurchasePrice(uint256 orbId) external view virtual returns (uint256) {
+        return _nextPurchaseOrderPrice(orbId);
+    }
+
+    function placePurchaseOrder(uint256 orbId, uint256 priceIfFinalized_) external payable virtual {
+        // - Only allowed if Orb is charging -- otherwise please use `purchase()`
+        if (os.invocations().isInvokable(orbId)) {
+            revert OrbInvokable();
+        }
+
+        // Only allowed if Keeper has enough funds to go until Orb is invokable again
+        uint256 lastInvocationTime = os.invocations().lastInvocationTime(orbId);
+        uint256 invocationPeriod = os.invocations().invocationPeriod(orbId);
+        if (_foreclosureTimestamp(orbId) < lastInvocationTime + invocationPeriod) {
+            revert InsufficientKeeperFunds();
+        }
+
+        uint256 _purchasePrice = _nextPurchaseOrderPrice(orbId);
+        if (msg.value < _purchasePrice) {
+            revert InsufficientFunds(msg.value, _purchasePrice);
+        }
+
+        address _lastPurchaser = purchaseOrder[orbId].purchaser;
+        if (_msgSender() == _lastPurchaser) {
+            revert AlreadyLastPurchaser();
+        }
+
+        fundsOf[orbId][_msgSender()] += msg.value - _purchasePrice;
+        uint256 _purchaseIndex = purchaseOrder[orbId].index;
+        // 0 if there isn't a purchase order
+        // potentially 0 if there is one
+        if (_lastPurchaser != address(0)) {
+            _purchaseIndex++;
+            // price paid by last purchaser, will not be 0 here
+            uint256 _lastPrice = _lastPurchaseOrderPrice(orbId);
+            uint256 _priceDifference = _purchasePrice - _lastPrice;
+            _addEarnings(_lastPurchaser, _priceDifference);
+        }
+        purchaseOrder[orbId] = PurchaseOrder(_purchaseIndex, _msgSender(), priceIfFinalized_, block.timestamp);
+        emit PurchaseOrderPlacement(orbId, _msgSender(), _purchasePrice);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //  FUNCTIONS: RELINQUISHMENT AND FORECLOSURE
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    function finalizePurchase(uint256 orbId) public virtual {
+        if (purchaseOrder[orbId].purchaser == address(0)) {
+            revert NoPurchaseOrder();
+        }
+        if (block.timestamp > purchaseOrder[orbId].timestamp + os.invocations().invocationPeriod(orbId) * 2) {
+            revert PurchaseOrderExpired();
+        }
+        if (!os.invocations().isInvokable(orbId)) {
+            revert OrbNotInvokable();
+        }
+
+        _settle(orbId);
+
+        address _keeper = ownershipRegistry.keeper(orbId);
+        address _creator = ownershipRegistry.creator(orbId);
+
+        // might be 0 if there isn't a purchase order:
+        uint256 _purchaseFunds = _purchaseOrderFunds(orbId);
+        address _lastPurchaser = purchaseOrder[orbId].purchaser;
+
+        if (_creator == _keeper) {
+            os.invocations().initializeOrbInvocationPeriod(orbId);
+            _addEarnings(_creator, _purchaseFunds);
+        } else {
+            uint256 royaltyShare = (_purchaseFunds * ownershipRegistry.purchaseRoyalty(orbId)) / os.feeDenominator();
+            _addEarnings(_creator, royaltyShare);
+            _addEarnings(_keeper, _purchaseFunds - royaltyShare);
+        }
+
+        _setPrice(orbId, purchaseOrder[orbId].price);
+        _resetPurchaseOrder(orbId);
+        ownershipRegistry.setKeeper(orbId, _lastPurchaser);
+
+        emit PurchaseFinalization(orbId, _keeper, _lastPurchaser, _purchaseFunds);
+    }
+
+    function _purchaseOrderFunds(uint256 orbId) internal view virtual returns (uint256) {
+        if (purchaseOrder[orbId].purchaser == address(0)) {
+            return 0;
+        }
+        // before first: funds available are 0
+        // after first: keeper price (index == 0)
+        // after second: also keeper price (index == 1)
+        // after third: 2nd purchase price (index == 2)
+        uint256 purchaseFundsIndex = purchaseOrder[orbId].index > 1 ? purchaseOrder[orbId].index - 1 : 0;
+
+        return ownershipRegistry.price(orbId) * (_NEXT_PURCHASE_PRICE_MULTIPLIER ** purchaseFundsIndex)
+            / os.feeDenominator();
+    }
+
+    function cancelPurchase(uint256 orbId) public virtual {
+        bool _canCancel = false;
+        if (purchaseOrder[orbId].purchaser == address(0)) {
+            revert NoPurchaseOrder();
+        }
+        if (_msgSender() == os.pledgeLockerAddress()) {
+            _canCancel = true;
+        }
+        if (
+            block.timestamp > purchaseOrder[orbId].timestamp + os.invocations().invocationPeriod(orbId) * 2
+                && !os.invocations().isInvokable(orbId) && !os.pledges().hasClaimablePledge(orbId)
+        ) {
+            _canCancel = true;
+        }
+        if (_canCancel == false) {
+            revert NotPermitted();
+        }
+
+        // - Purchase funds are returned to purchaserAddress as funds (fee not charged)
+        fundsOf[orbId][purchaseOrder[orbId].purchaser] += _purchaseOrderFunds(orbId);
+        _resetPurchaseOrder(orbId);
+
+        emit PurchaseCancellation(orbId);
+    }
+
+    function assignFunds(uint256 orbId, address to) external payable virtual onlyOwnershipContract {
+        fundsOf[orbId][to] += msg.value;
+    }
+
+    function resetSettlementTime(uint256 orbId) external virtual onlyOwnershipContract {
+        lastSettlementTime[orbId] = block.timestamp;
+    }
+
+    function transferFunds(uint256 orbId, address from, address to) external virtual onlyOwnershipContract {
+        uint256 keeperFunds = fundsOf[orbId][from];
+        fundsOf[orbId][from] = 0;
+        fundsOf[orbId][to] += keeperFunds;
+    }
+
+    function _resetPurchaseOrder(uint256 orbId) internal virtual {
+        purchaseOrder[orbId] = PurchaseOrder(0, address(0), 0, 0);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //  FUNCTIONS: UPGRADING
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// @notice  Returns the version of the Orb. Internal constant `_VERSION` will be increased with each upgrade.
+    /// @return  orbVersion  Version of the Orb.
+    function version() public pure virtual returns (uint256 orbVersion) {
+        return _VERSION;
+    }
+
+    /// @dev  Authorizes owner address to upgrade the contract.
+    // solhint-disable no-empty-blocks
+    function _authorizeUpgrade(address newImplementation_) internal virtual override onlyOwner {}
+
+    function _platformFee() internal virtual override returns (uint256) {
+        return os.platformFee();
+    }
+
+    function _feeDenominator() internal virtual override returns (uint256) {
+        return os.feeDenominator();
+    }
+
+    function _earningsWithdrawalAddress(address user) internal virtual override returns (address) {
+        return os.earningsWithdrawalAddress(user);
+    }
+}

--- a/src/InvocationAccessVendor.sol
+++ b/src/InvocationAccessVendor.sol
@@ -92,7 +92,7 @@ contract InvocationAccessVendor is Earnable, OwnableUpgradeable, UUPSUpgradeable
         if (os.ownership().keeper(orbId) == os.ownershipRegistryAddress()) {
             revert NotOwnedBySolventKeeper();
         }
-        if (!os.ownership().keeperSolvent(orbId)) {
+        if (!os.keepership().keeperSolvent(orbId)) {
             revert NotOwnedBySolventKeeper();
         }
 
@@ -107,7 +107,7 @@ contract InvocationAccessVendor is Earnable, OwnableUpgradeable, UUPSUpgradeable
     /// @param   invocationId  The invocation id
     /// @param   price_        New price for the invocation
     function setPrice(uint256 orbId, uint256 invocationId, uint256 price_) external virtual {
-        if (_msgSender() != os.ownership().keeper(orbId) || !os.ownership().keeperSolvent(orbId)) {
+        if (_msgSender() != os.ownership().keeper(orbId) || !os.keepership().keeperSolvent(orbId)) {
             revert NotKeeper();
         }
         price[orbId][invocationId] = price_;

--- a/src/InvocationAccessVendor.sol
+++ b/src/InvocationAccessVendor.sol
@@ -6,6 +6,9 @@ import {OwnableUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/cont
 import {UUPSUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import {OrbSystem} from "./OrbSystem.sol";
+import {OwnershipRegistry} from "./OwnershipRegistry.sol";
+import {HarbergerTaxKeepership} from "./HarbergerTaxKeepership.sol";
+import {InvocationRegistry} from "./InvocationRegistry.sol";
 
 /// @title   Orb Invocation Access Vendor
 /// @author  Jonas Lekevicius
@@ -27,7 +30,9 @@ contract InvocationAccessVendor is Earnable, OwnableUpgradeable, UUPSUpgradeable
         accessPurchased;
 
     /// Addresses of all system contracts
-    OrbSystem public os;
+    OrbSystem public orbSystem;
+    OwnershipRegistry public ownership;
+    HarbergerTaxKeepership public keepership;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //  EVENTS
@@ -63,7 +68,12 @@ contract InvocationAccessVendor is Earnable, OwnableUpgradeable, UUPSUpgradeable
         __Ownable_init(_msgSender());
         __UUPSUpgradeable_init();
 
-        os = OrbSystem(os_);
+        orbSystem = OrbSystem(os_);
+    }
+
+    function setSystemContracts() external {
+        ownership = OwnershipRegistry(orbSystem.ownershipRegistryAddress());
+        keepership = HarbergerTaxKeepership(orbSystem.harbergerTaxKeepershipAddress());
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -85,18 +95,19 @@ contract InvocationAccessVendor is Earnable, OwnableUpgradeable, UUPSUpgradeable
         if (accessPurchased[orbId][invocationId][_msgSender()] > 0) {
             revert AlreadyPurchased();
         }
-        (, uint256 responseTimestamp) = os.invocations().responses(orbId, invocationId);
+        (, uint256 responseTimestamp) =
+            InvocationRegistry(orbSystem.invocationRegistryAddress()).responses(orbId, invocationId);
         if (responseTimestamp == 0) {
             revert ResponseDoesNotExist();
         }
-        if (os.ownership().keeper(orbId) == os.ownershipRegistryAddress()) {
+        if (ownership.keeper(orbId) == orbSystem.ownershipRegistryAddress()) {
             revert NotOwnedBySolventKeeper();
         }
-        if (!os.keepership().keeperSolvent(orbId)) {
+        if (!keepership.keeperSolvent(orbId)) {
             revert NotOwnedBySolventKeeper();
         }
 
-        _addEarnings(os.ownership().keeper(orbId), msg.value);
+        _addEarnings(ownership.keeper(orbId), msg.value);
         accessPurchased[orbId][invocationId][_msgSender()] = block.timestamp;
 
         emit AccessPurchase(orbId, invocationId, _msgSender(), msg.value);
@@ -107,7 +118,7 @@ contract InvocationAccessVendor is Earnable, OwnableUpgradeable, UUPSUpgradeable
     /// @param   invocationId  The invocation id
     /// @param   price_        New price for the invocation
     function setPrice(uint256 orbId, uint256 invocationId, uint256 price_) external virtual {
-        if (_msgSender() != os.ownership().keeper(orbId) || !os.keepership().keeperSolvent(orbId)) {
+        if (_msgSender() != ownership.keeper(orbId) || !keepership.keeperSolvent(orbId)) {
             revert NotKeeper();
         }
         price[orbId][invocationId] = price_;
@@ -129,15 +140,7 @@ contract InvocationAccessVendor is Earnable, OwnableUpgradeable, UUPSUpgradeable
     // solhint-disable no-empty-blocks
     function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner {}
 
-    function _platformFee() internal virtual override returns (uint256) {
-        return os.platformFee();
-    }
-
-    function _feeDenominator() internal virtual override returns (uint256) {
-        return os.feeDenominator();
-    }
-
     function _earningsWithdrawalAddress(address user) internal virtual override returns (address) {
-        return os.earningsWithdrawalAddress(user);
+        return orbSystem.earningsWithdrawalAddress(user);
     }
 }

--- a/src/InvocationRegistry.sol
+++ b/src/InvocationRegistry.sol
@@ -370,6 +370,11 @@ contract InvocationRegistry is OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function _invoke(uint256 orbId, address invoker_, bytes32 contentHash_) internal virtual {
+        (, address purchaser,,) = os.ownership().purchaseOrder(orbId);
+        if (purchaser != address(0)) {
+            revert NotInvokable();
+        }
+
         invocationCount[orbId] += 1;
         uint256 invocationId = invocationCount[orbId]; // starts at 1
 

--- a/src/InvocationRegistry.sol
+++ b/src/InvocationRegistry.sol
@@ -164,7 +164,7 @@ contract InvocationRegistry is OwnableUpgradeable, UUPSUpgradeable {
             return false;
         }
 
-        if (os.ownership().keeperSolvent(orbId) == false) {
+        if (os.keepership().keeperSolvent(orbId) == false) {
             return false;
         }
 
@@ -191,7 +191,7 @@ contract InvocationRegistry is OwnableUpgradeable, UUPSUpgradeable {
             return type(uint256).max;
         }
         // 1000 is used to avoid floating point arithmetic
-        uint256 invocationsInTaxPeriod = os.ownership().keeperTaxPeriod() * 1000 / invocationPeriod[orbId];
+        uint256 invocationsInTaxPeriod = os.keepership().keeperTaxPeriod() * 1000 / invocationPeriod[orbId];
         return (invocationsInTaxPeriod * os.feeDenominator()) / 1000;
 
         // test for 14 days invocation period:
@@ -210,7 +210,7 @@ contract InvocationRegistry is OwnableUpgradeable, UUPSUpgradeable {
         }
         // 1000 is used to avoid floating point arithmetic
         uint256 buybacksInTaxPeriod = keeperTax_ * 1000 / os.feeDenominator();
-        return os.ownership().keeperTaxPeriod() * 1000 / buybacksInTaxPeriod;
+        return os.keepership().keeperTaxPeriod() * 1000 / buybacksInTaxPeriod;
 
         // buybacksInTaxPeriod for 100% tax  = 100_00  * 1000 / 100_00 = 100_000_00  / 100_00 = 1000.00 or 1
         // buybacksInTaxPeriod for 200% tax  = 200_00  * 1000 / 100_00 = 200_000_00  / 100_00 = 2000.00 or 2
@@ -308,7 +308,7 @@ contract InvocationRegistry is OwnableUpgradeable, UUPSUpgradeable {
         }
 
         // Must settle, so tax pausing is accounted for
-        os.ownership().settle(orbId);
+        os.keepership().settle(orbId);
 
         invocationPeriod[orbId] = invocationPeriod_;
         emit InvocationPeriodUpdate(orbId, invocationPeriod_);
@@ -370,7 +370,8 @@ contract InvocationRegistry is OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function _invoke(uint256 orbId, address invoker_, bytes32 contentHash_) internal virtual {
-        (, address purchaser,,) = os.ownership().purchaseOrder(orbId);
+        // Keeper shouldn't be able to invoke the Orb if there's a Purchase Order
+        (, address purchaser,,) = os.keepership().purchaseOrder(orbId);
         if (purchaser != address(0)) {
             revert NotInvokable();
         }
@@ -413,7 +414,7 @@ contract InvocationRegistry is OwnableUpgradeable, UUPSUpgradeable {
             }
             if (os.ownership().keeper(orbId) != os.ownershipRegistryAddress()) {
                 // Settle to apply Harberger tax discount, and reset for potential discounts in the future
-                os.ownership().settle(orbId);
+                os.keepership().settle(orbId);
             }
         }
 

--- a/src/OrbSystem.sol
+++ b/src/OrbSystem.sol
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {OwnershipRegistry} from "./OwnershipRegistry.sol";
-import {HarbergerTaxKeepership} from "./HarbergerTaxKeepership.sol";
-import {InvocationRegistry} from "./InvocationRegistry.sol";
-import {PledgeLocker} from "./PledgeLocker.sol";
-import {InvocationTipJar} from "./InvocationTipJar.sol";
-import {InvocationAccessVendor} from "./InvocationAccessVendor.sol";
-
 import {IAllocationMethod} from "./allocation/IAllocationMethod.sol";
 
 import {OwnableUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import {OwnershipRegistry} from "./OwnershipRegistry.sol";
+import {InvocationRegistry} from "./InvocationRegistry.sol";
+import {PledgeLocker} from "./PledgeLocker.sol";
 
 contract OrbSystem is OwnableUpgradeable, UUPSUpgradeable {
     event AllocationContractAuthorization(address indexed contractAddress, bool indexed authorized);
@@ -86,34 +83,6 @@ contract OrbSystem is OwnableUpgradeable, UUPSUpgradeable {
         pledgeLockerAddress = pledgeLockerAddress_;
         invocationTipJarAddress = invocationTipJarAddress_;
         invocationAccessVendorAddress = invocationAccessVendorAddress_;
-    }
-
-    function ownership() public view returns (OwnershipRegistry) {
-        return OwnershipRegistry(ownershipRegistryAddress);
-    }
-
-    function keepership() public view returns (HarbergerTaxKeepership) {
-        return HarbergerTaxKeepership(harbergerTaxKeepershipAddress);
-    }
-
-    function invocations() public view returns (InvocationRegistry) {
-        return InvocationRegistry(invocationRegistryAddress);
-    }
-
-    function pledges() public view returns (PledgeLocker) {
-        return PledgeLocker(pledgeLockerAddress);
-    }
-
-    function tips() public view returns (InvocationTipJar) {
-        return InvocationTipJar(invocationTipJarAddress);
-    }
-
-    function accessVendor() public view returns (InvocationAccessVendor) {
-        return InvocationAccessVendor(invocationAccessVendorAddress);
-    }
-
-    function feeDenominator() public pure returns (uint256) {
-        return _FEE_DENOMINATOR;
     }
 
     function platformFee() public pure returns (uint256) {

--- a/src/OrbSystem.sol
+++ b/src/OrbSystem.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.20;
 
 import {OwnershipRegistry} from "./OwnershipRegistry.sol";
+import {HarbergerTaxKeepership} from "./HarbergerTaxKeepership.sol";
 import {InvocationRegistry} from "./InvocationRegistry.sol";
 import {PledgeLocker} from "./PledgeLocker.sol";
 import {InvocationTipJar} from "./InvocationTipJar.sol";
@@ -27,6 +28,8 @@ contract OrbSystem is OwnableUpgradeable, UUPSUpgradeable {
 
     /// Address of Ownership Registry contract
     address public ownershipRegistryAddress;
+    /// Address of Harberger Tax Keepership contract
+    address public harbergerTaxKeepershipAddress;
     /// Address of Invocation Registry contract
     address public invocationRegistryAddress;
     /// Address of Pledge Locker contract
@@ -64,18 +67,21 @@ contract OrbSystem is OwnableUpgradeable, UUPSUpgradeable {
 
     /// @notice  Allows the owner address to set the contract addresses.
     /// @param   ownershipRegistryAddress_  Address of the Ownership Registry contract.
+    /// @param   harbergerTaxKeepershipAddress_  Address of the Harberger Tax Keepership contract.
     /// @param   invocationRegistryAddress_  Address of the Invocation Registry contract.
     /// @param   pledgeLockerAddress_  Address of the Pledge Locker contract.
     /// @param   invocationTipJarAddress_  Address of the Invocation Tip Jar contract.
     /// @param   invocationAccessVendorAddress_  Address of the Invocation Access Vendor contract.
     function setAddresses(
         address ownershipRegistryAddress_,
+        address harbergerTaxKeepershipAddress_,
         address invocationRegistryAddress_,
         address pledgeLockerAddress_,
         address invocationTipJarAddress_,
         address invocationAccessVendorAddress_
     ) external onlyOwner {
         ownershipRegistryAddress = ownershipRegistryAddress_;
+        harbergerTaxKeepershipAddress = harbergerTaxKeepershipAddress_;
         invocationRegistryAddress = invocationRegistryAddress_;
         pledgeLockerAddress = pledgeLockerAddress_;
         invocationTipJarAddress = invocationTipJarAddress_;
@@ -84,6 +90,10 @@ contract OrbSystem is OwnableUpgradeable, UUPSUpgradeable {
 
     function ownership() public view returns (OwnershipRegistry) {
         return OwnershipRegistry(ownershipRegistryAddress);
+    }
+
+    function keepership() public view returns (HarbergerTaxKeepership) {
+        return HarbergerTaxKeepership(harbergerTaxKeepershipAddress);
     }
 
     function invocations() public view returns (InvocationRegistry) {

--- a/src/OwnershipRegistry.sol
+++ b/src/OwnershipRegistry.sol
@@ -37,8 +37,9 @@ contract OwnershipRegistry is Earnable, OwnableUpgradeable, UUPSUpgradeable {
     // Purchasing Events
     event PriceUpdate(uint256 indexed orbId, address indexed keeper, uint256 newPrice);
     event Purchase(uint256 indexed orbId, address indexed seller, address indexed buyer, uint256 price);
-    event PurchaseFinalized(uint256 indexed orbId, address indexed seller, address indexed buyer, uint256 price);
-    event PurchaseCancelled(uint256 indexed orbId);
+    event PurchaseOrderPlacement(uint256 indexed orbId, address indexed purchaser, uint256 price);
+    event PurchaseFinalization(uint256 indexed orbId, address indexed seller, address indexed buyer, uint256 price);
+    event PurchaseCancellation(uint256 indexed orbId);
 
     // Orb Ownership Events
     event Foreclosure(uint256 indexed orbId, address indexed formerKeeper);
@@ -737,6 +738,7 @@ contract OwnershipRegistry is Earnable, OwnableUpgradeable, UUPSUpgradeable {
             _addEarnings(_lastPurchaser, _priceDifference);
         }
         purchaseOrder[orbId] = PurchaseOrder(_purchaseIndex, _msgSender(), priceIfFinalized_, block.timestamp);
+        emit PurchaseOrderPlacement(orbId, _msgSender(), _purchasePrice);
     }
 
     /// @dev    Does not check if the new price differs from the previous price: no risk. Limits the price to
@@ -793,7 +795,7 @@ contract OwnershipRegistry is Earnable, OwnableUpgradeable, UUPSUpgradeable {
         _resetPurchaseOrder(orbId);
         keeper[orbId] = _lastPurchaser;
 
-        emit PurchaseFinalized(orbId, _keeper, _lastPurchaser, _purchaseFunds);
+        emit PurchaseFinalization(orbId, _keeper, _lastPurchaser, _purchaseFunds);
     }
 
     function _purchaseOrderFunds(uint256 orbId) internal view virtual returns (uint256) {
@@ -831,7 +833,7 @@ contract OwnershipRegistry is Earnable, OwnableUpgradeable, UUPSUpgradeable {
         fundsOf[orbId][purchaseOrder[orbId].purchaser] += _purchaseOrderFunds(orbId);
         _resetPurchaseOrder(orbId);
 
-        emit PurchaseCancelled(orbId);
+        emit PurchaseCancellation(orbId);
     }
 
     function _resetPurchaseOrder(uint256 orbId) internal virtual {

--- a/src/PledgeLocker.sol
+++ b/src/PledgeLocker.sol
@@ -336,6 +336,11 @@ contract PledgeLocker is OwnableUpgradeable, UUPSUpgradeable {
 
         _transferPledgeTo(orbId, _invoker);
 
+        (, address purchaser,,) = os.ownership().purchaseOrder(orbId);
+        if (purchaser != address(0)) {
+            os.ownership().cancelPurchase(orbId);
+        }
+
         emit PledgeClaimed(orbId, _invoker);
     }
 

--- a/src/PledgeLocker.sol
+++ b/src/PledgeLocker.sol
@@ -336,9 +336,9 @@ contract PledgeLocker is OwnableUpgradeable, UUPSUpgradeable {
 
         _transferPledgeTo(orbId, _invoker);
 
-        (, address purchaser,,) = os.ownership().purchaseOrder(orbId);
+        (, address purchaser,,) = os.keepership().purchaseOrder(orbId);
         if (purchaser != address(0)) {
-            os.ownership().cancelPurchase(orbId);
+            os.keepership().cancelPurchase(orbId);
         }
 
         emit PledgeClaimed(orbId, _invoker);

--- a/src/allocation/EnglishAuctionAllocation.sol
+++ b/src/allocation/EnglishAuctionAllocation.sol
@@ -28,6 +28,7 @@ contract EnglishAuctionAllocation is AllocationMethod, OwnableUpgradeable, UUPSU
 
     /// Version. Value: 1.
     uint256 private constant _VERSION = 1;
+    uint256 internal constant _FEE_DENOMINATOR = 100_00;
 
     // Auction State Variables
 
@@ -61,7 +62,7 @@ contract EnglishAuctionAllocation is AllocationMethod, OwnableUpgradeable, UUPSU
     mapping(uint256 orbId => uint256) public initialPrice;
 
     function initializeOrb(uint256 orbId) public override onlyOwnershipRegistry {
-        if (_msgSender() != os.ownershipRegistryAddress()) {
+        if (_msgSender() != orbSystem.ownershipRegistryAddress()) {
             revert NotOwnershipRegistryContract();
         }
         if (minimumDuration[orbId] > 0) {
@@ -87,7 +88,7 @@ contract EnglishAuctionAllocation is AllocationMethod, OwnableUpgradeable, UUPSU
     }
 
     function _isReallocation(uint256 orbId) internal view virtual override returns (bool) {
-        OwnershipRegistry _ownership = OwnershipRegistry(os.ownershipRegistryAddress());
+        OwnershipRegistry _ownership = OwnershipRegistry(orbSystem.ownershipRegistryAddress());
         return _ownership.allocationBeneficiary(orbId) != _ownership.creator(orbId);
     }
 
@@ -96,7 +97,7 @@ contract EnglishAuctionAllocation is AllocationMethod, OwnableUpgradeable, UUPSU
     ///          after auction is finalized. Emits `AuctionStart`.
     ///          V2 adds `onlyHonored` modifier to require active Oath to start auction.
     function start(uint256 orbId) external virtual override onlyOwnershipRegistry onlyInactive(orbId) {
-        if (os.ownershipRegistryAddress() != os.ownership().keeper(orbId)) {
+        if (orbSystem.ownershipRegistryAddress() != ownership.keeper(orbId)) {
             revert ContractDoesNotHoldOrb();
         }
 
@@ -144,7 +145,7 @@ contract EnglishAuctionAllocation is AllocationMethod, OwnableUpgradeable, UUPSU
             revert AllocationNotActive();
         }
 
-        OwnershipRegistry _ownership = OwnershipRegistry(os.ownershipRegistryAddress());
+        OwnershipRegistry _ownership = OwnershipRegistry(orbSystem.ownershipRegistryAddress());
         address _leadingBidder = leadingBidder[orbId];
         uint256 _leadingBid = leadingBid[orbId];
         uint256 _leadingBidderFunds = 0;
@@ -160,18 +161,17 @@ contract EnglishAuctionAllocation is AllocationMethod, OwnableUpgradeable, UUPSU
                 uint256 duration_ = endTime[orbId] - startTime[orbId];
                 uint256 reallocationRoyalty = _ownership.reallocationRoyalty(orbId);
 
-                uint256 _allocationMinimumRoyalty =
-                    (_ownership.keeperTax(orbId) * duration_) / os.keepership().keeperTaxPeriod();
+                uint256 _allocationMinimumRoyalty = (_ownership.keeperTax(orbId) * duration_) / _KEEPER_TAX_PERIOD;
                 uint256 _actualAllocationRoyalty =
                     _allocationMinimumRoyalty > reallocationRoyalty ? _allocationMinimumRoyalty : reallocationRoyalty;
 
-                uint256 royaltyShare = (_leadingBid * _actualAllocationRoyalty) / os.feeDenominator();
+                uint256 royaltyShare = (_leadingBid * _actualAllocationRoyalty) / _FEE_DENOMINATOR;
                 _addEarnings(_creator, royaltyShare);
                 _addEarnings(_beneficiary, _leadingBid - royaltyShare);
             }
         }
 
-        os.ownership().finalizeAllocation{value: _leadingBidderFunds}(
+        ownership.finalizeAllocation{value: _leadingBidderFunds}(
             orbId, _leadingBidder, _leadingBidderFunds, initialPrice[orbId]
         );
 
@@ -253,8 +253,8 @@ contract EnglishAuctionAllocation is AllocationMethod, OwnableUpgradeable, UUPSU
         if (priceIfWon_ > _MAXIMUM_PRICE) {
             revert InvalidPrice(priceIfWon_);
         }
-        if (priceIfWon_ < os.ownership().minimumPrice(orbId)) {
-            revert PriceTooLow(priceIfWon_, os.ownership().minimumPrice(orbId));
+        if (priceIfWon_ < ownership.minimumPrice(orbId)) {
+            revert PriceTooLow(priceIfWon_, ownership.minimumPrice(orbId));
         }
 
         fundsOf[orbId][_msgSender()] = totalFunds;

--- a/src/allocation/EnglishAuctionAllocation.sol
+++ b/src/allocation/EnglishAuctionAllocation.sol
@@ -161,7 +161,7 @@ contract EnglishAuctionAllocation is AllocationMethod, OwnableUpgradeable, UUPSU
                 uint256 reallocationRoyalty = _ownership.reallocationRoyalty(orbId);
 
                 uint256 _allocationMinimumRoyalty =
-                    (_ownership.keeperTax(orbId) * duration_) / _ownership.keeperTaxPeriod();
+                    (_ownership.keeperTax(orbId) * duration_) / os.keepership().keeperTaxPeriod();
                 uint256 _actualAllocationRoyalty =
                     _allocationMinimumRoyalty > reallocationRoyalty ? _allocationMinimumRoyalty : reallocationRoyalty;
 

--- a/src/delegation/EnglishAuctionDelegation.sol
+++ b/src/delegation/EnglishAuctionDelegation.sol
@@ -133,9 +133,9 @@ contract EnglishAuctionDelegation is DelegationMethod, OwnableUpgradeable, UUPSU
         uint256 _leadingBid = leadingBid[orbId];
 
         fundsOf[orbId][_leadingBidder] -= _leadingBid;
-        _addEarnings(os.ownership().keeper(orbId), _leadingBid);
+        _addEarnings(ownership.keeper(orbId), _leadingBid);
 
-        os.invocations().invokeDelegated(orbId, _leadingBidder, delegationHash[orbId]);
+        invocations.invokeDelegated(orbId, _leadingBidder, delegationHash[orbId]);
 
         emit DelegationFinalization(orbId, _leadingBidder, _leadingBid);
         _reset(orbId);
@@ -159,7 +159,7 @@ contract EnglishAuctionDelegation is DelegationMethod, OwnableUpgradeable, UUPSU
         if (minimumDuration_ == 0) {
             revert InvalidAuctionDuration(minimumDuration_);
         }
-        if (minimumDuration_ > os.invocations().invocationPeriod(orbId)) {
+        if (minimumDuration_ > invocations.invocationPeriod(orbId)) {
             revert InvalidAuctionDuration(minimumDuration_);
         }
 

--- a/src/delegation/PriceDelegation.sol
+++ b/src/delegation/PriceDelegation.sol
@@ -74,7 +74,7 @@ contract PriceDelegation is DelegationMethod, OwnableUpgradeable, UUPSUpgradeabl
         delegationExpiration[orbId] = block.timestamp + delegationExpiration[orbId];
 
         emit DelegationPurchase(orbId, _msgSender(), price[orbId]);
-        if (os.invocations().isInvokable(orbId)) {
+        if (invocations.isInvokable(orbId)) {
             finalize(orbId);
         }
     }
@@ -120,9 +120,9 @@ contract PriceDelegation is DelegationMethod, OwnableUpgradeable, UUPSUpgradeabl
         address delegate = delegateAddress[orbId];
 
         fundsOf[orbId][delegate] -= _price;
-        _addEarnings(os.ownership().keeper(orbId), _price);
+        _addEarnings(ownership.keeper(orbId), _price);
 
-        os.invocations().invokeDelegated(orbId, delegate, delegationHash[orbId]);
+        invocations.invokeDelegated(orbId, delegate, delegationHash[orbId]);
 
         emit DelegationFinalization(orbId, delegate, _price);
         _reset(orbId);


### PR DESCRIPTION
Purchase Orders aim to solve potential ruggability of Orbs.

**Problem:** Orb could get abandoned at any point, even if there’s a pledge. If you purchase the Orb before its cooldown expires, then you might never get to ask a question (or claim the pledge, as it goes to the last invoker), despite paying for the Orb.

**Solution:** replacing immediate purchases with purchase orders while Orb is charging, holding these funds until Orb is invokable, and then executing the purchase. If the pledge is claimed, or Orb does not become invokable until an expiration date, then the order is cancelled, and funds are returned to the purchasers.

Additional mechanics:
- Purchase Order can only be made if Keeper has enough funds to cover ownership until Orb is charged.
- Subsequent purchase orders are more expense (each time price increases 1.2x), with the difference between last and current price going to the previous purchaser as compensation.
- Instant purchases are still always allowed. UI will warn users about risks.
- Changing price, relinquishing Orb or withdrawing funds is not permitted for the Keeper if there is a Purchase Order.
- Foreclosure finalizes the Purchase Order, instead of running re-allocation.
- Pledge claim cancels the Purchase Order.
- Order can also be manually canceled after 2 invocation periods since it was made, if Orb is still not invokable.